### PR TITLE
feat: 新增 WebDAV 图床同步支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@
 
 ## ☁️ 图床配置
 
-本插件支持 **stardots** 和 **Cloudflare R2** 两种图床。
+本插件支持 **stardots**、**Cloudflare R2** 和 **WebDAV** 三种图床。
 
 ### 方案一：Stardots 图床（国内访问友好）
 
@@ -195,11 +195,45 @@
 > - 支持自定义域名
 > - 智能上传记录，避免重复上传相同文件
 
+### 方案三：WebDAV 图床/云存储（自建友好）
+
+WebDAV 适合用于 NAS、Alist、Nextcloud、坚果云、群晖等服务，可作为表情包云端同步存储。若 WebDAV 服务本身不提供公开外链，也可以只用于备份和多设备同步。
+
+1. **准备 WebDAV 服务**：确认你的服务支持 WebDAV，并记录 WebDAV 根地址、用户名和密码/应用密码。
+
+2. **配置插件**：在插件设置中选择 `webdav` 并填写：
+   ```yaml
+         # WebDAV 根地址 (url)
+         url: "https://example.com/dav"
+         # WebDAV 用户名 (username)
+         username: "your_username"
+         # WebDAV 密码或应用密码 (password)
+         password: "your_password"
+         # 远端目录 (base_path)
+         base_path: "memes"
+         # 公开访问根地址（可选）(public_url)
+         public_url: "https://cdn.example.com/memes"
+         # 是否校验 SSL 证书 (verify_ssl)
+         verify_ssl: true
+         # 请求超时时间，单位秒 (timeout)
+         timeout: 30
+   ```
+
+3. **使用图床功能**：
+   - 发送 `/表情管理 同步状态` 查看同步状态
+   - 发送 `/表情管理 同步到云端` 上传表情包到 WebDAV
+   - 发送 `/表情管理 从云端同步` 从 WebDAV 下载表情包
+
+> **WebDAV 注意事项**：
+> - `base_path` 是 WebDAV 内保存表情包的目录，插件会自动创建缺失目录
+> - `public_url` 可选；不填写时仍可同步，但生成的 URL 可能需要登录才能访问
+> - 自签名证书服务可将 `verify_ssl` 设置为 `false`
+
 ## ⚙️ 配置说明
 
 插件配置项包括：
 
-- `image_host`: 选择图床服务 (支持 stardots 和 cloudflare_r2)
+- `image_host`: 选择图床服务 (支持 stardots、cloudflare_r2 和 webdav)
 - `image_host_config`: 图床配置信息（根据选择的图床服务填写相应配置）
 - `webui_port`: WebUI 服务端口号
 - `max_emotions_per_message`: 每条消息最大表情数量

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -6,7 +6,8 @@
     "default": "stardots",
     "options": [
       "stardots",
-      "cloudflare_r2"
+      "cloudflare_r2",
+      "webdav"
     ]
   },
   "image_host_config": {
@@ -62,6 +63,50 @@
             "description": "自定义CDN域名（可选）",
             "type": "string",
             "hint": "自定义CDN域名，例如：https://cdn.yourdomain.com"
+          }
+        }
+      },
+      "webdav": {
+        "description": "WebDAV 图床配置",
+        "type": "object",
+        "items": {
+          "url": {
+            "description": "WebDAV 地址",
+            "type": "string",
+            "hint": "请输入 WebDAV 根地址，例如：https://example.com/dav"
+          },
+          "username": {
+            "description": "用户名",
+            "type": "string",
+            "hint": "请输入 WebDAV 用户名"
+          },
+          "password": {
+            "description": "密码或应用密码",
+            "type": "string",
+            "hint": "请输入 WebDAV 密码或应用密码"
+          },
+          "base_path": {
+            "description": "远端目录",
+            "type": "string",
+            "default": "memes",
+            "hint": "表情包在 WebDAV 中保存的目录，例如：memes"
+          },
+          "public_url": {
+            "description": "公开访问地址（可选）",
+            "type": "string",
+            "hint": "如需生成外链，请填写公开访问根地址，例如：https://cdn.example.com/memes"
+          },
+          "verify_ssl": {
+            "description": "校验 SSL 证书",
+            "type": "bool",
+            "default": true,
+            "hint": "自签名证书服务可关闭此项"
+          },
+          "timeout": {
+            "description": "请求超时时间（秒）",
+            "type": "int",
+            "default": 30,
+            "hint": "WebDAV 上传、下载、列表请求的超时时间"
           }
         }
       }

--- a/backend/api.py
+++ b/backend/api.py
@@ -30,6 +30,8 @@ def _get_provider_label(img_sync) -> str:
         return "Cloudflare R2"
     if provider_type == "stardots":
         return "StarDots"
+    if provider_type == "webdav":
+        return "WebDAV"
 
     provider = getattr(img_sync, "provider", None)
     if provider is not None:
@@ -521,7 +523,7 @@ async def get_img_host_sync_status():
         plugin_config = current_app.config.get("PLUGIN_CONFIG", {})
         img_sync = plugin_config.get("img_sync")
         if not img_sync:
-            return jsonify({"error": "图床服务未配置"}), 400
+            return jsonify({"message": "图床服务未配置", "error": "图床服务未配置"}), 400
 
         status = img_sync.check_status()
         status["upload_count"] = len(status.get("to_upload", []))
@@ -529,7 +531,7 @@ async def get_img_host_sync_status():
         status["provider_label"] = _get_provider_label(img_sync)
         return jsonify(status)
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"message": str(e), "error": str(e)}), 500
 
 
 @api.route("/img_host/sync/upload", methods=["POST"])

--- a/image_host/img_sync.py
+++ b/image_host/img_sync.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from .core.sync_manager import SyncManager
 from .core.upload_tracker import UploadTracker
-from .providers import CloudflareR2Provider, StarDotsProvider
+from .providers import CloudflareR2Provider, StarDotsProvider, WebDAVProvider
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class ImageSync:
         Args:
             config: 包含图床配置信息的字典
             local_dir: 本地图片目录的路径
-            provider_type: 图床提供者类型，可选 "stardots" 或 "cloudflare_r2"
+            provider_type: 图床提供者类型，可选 "stardots"、"cloudflare_r2" 或 "webdav"
         """
         self.config = config
         self.local_dir = Path(local_dir)
@@ -67,6 +67,8 @@ class ImageSync:
             )
         elif provider_type == "cloudflare_r2":
             self.provider = CloudflareR2Provider(config)
+        elif provider_type == "webdav":
+            self.provider = WebDAVProvider({**config, "local_dir": str(local_dir)})
         else:
             raise ValueError(f"不支持的图床提供者类型: {provider_type}")
 
@@ -260,6 +262,10 @@ def run_sync_process(config: dict[str, str], local_dir: str, task: str):
             # 如果是 stardots 配置
             provider_config = config["stardots"]
             provider_type = "stardots"
+        elif "webdav" in config:
+            # 如果是完整配置，提取 webdav 部分
+            provider_config = config["webdav"]
+            provider_type = "webdav"
         elif "account_id" in config:
             # 如果是直接的 R2 配置
             provider_config = config
@@ -268,6 +274,12 @@ def run_sync_process(config: dict[str, str], local_dir: str, task: str):
             # 如果是直接的 stardots 配置
             provider_config = config
             provider_type = "stardots"
+        elif config.get("provider") == "webdav" or all(
+            config.get(field) for field in ("url", "username", "password")
+        ):
+            # 如果是直接的 WebDAV 配置
+            provider_config = config
+            provider_type = "webdav"
         else:
             logger.error(f"无法识别的配置格式: {list(config.keys())}")
             sys.exit(1)

--- a/image_host/providers/__init__.py
+++ b/image_host/providers/__init__.py
@@ -3,5 +3,11 @@
 from .cloudflare_r2_provider import CloudflareR2Provider
 from .provider_template import ProviderTemplate as ImageHostProvider
 from .stardots_provider import StarDotsProvider
+from .webdav_provider import WebDAVProvider
 
-__all__ = ["StarDotsProvider", "CloudflareR2Provider", "ImageHostProvider"]
+__all__ = [
+    "StarDotsProvider",
+    "CloudflareR2Provider",
+    "WebDAVProvider",
+    "ImageHostProvider",
+]

--- a/image_host/providers/webdav_provider.py
+++ b/image_host/providers/webdav_provider.py
@@ -1,0 +1,269 @@
+import logging
+import posixpath
+import urllib.parse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import TypedDict
+
+import requests
+
+from ..interfaces.image_host import ImageHostInterface
+
+logger = logging.getLogger(__name__)
+
+
+class WebDAVError(Exception):
+    """WebDAV 图床基础异常"""
+
+
+class AuthenticationError(WebDAVError):
+    """认证失败异常"""
+
+
+class NetworkError(WebDAVError):
+    """网络请求失败异常"""
+
+
+class InvalidResponseError(WebDAVError):
+    """响应格式异常"""
+
+
+class ImageInfo(TypedDict):
+    id: str
+    url: str
+    filename: str
+    category: str
+    size: int
+
+
+class WebDAVProvider(ImageHostInterface):
+    """WebDAV 图床/云存储提供者。"""
+
+    SUPPORTED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
+
+    def __init__(self, config: dict[str, str]):
+        required_fields = ["url", "username", "password"]
+        missing_fields = [field for field in required_fields if not config.get(field)]
+        if missing_fields:
+            raise ValueError(f"WebDAV 配置缺少必要字段: {', '.join(missing_fields)}")
+
+        self.config = config
+        self.base_url = str(config["url"]).rstrip("/")
+        self.username = config["username"]
+        self.password = config["password"]
+        self.base_path = self._normalize_path(config.get("base_path", "memes"))
+        self.public_url = str(config.get("public_url", "")).rstrip("/")
+        self.local_dir = Path(config.get("local_dir", "")) if config.get("local_dir") else None
+        self.timeout = int(config.get("timeout", 30) or 30)
+        self.verify_ssl = self._parse_bool(config.get("verify_ssl", True))
+
+        self.session = requests.Session()
+        self.session.auth = (self.username, self.password)
+
+        logger.info("初始化 WebDAV 图床: %s/%s", self.base_url, self.base_path)
+
+    def upload_image(self, file_path: Path) -> ImageInfo:
+        """上传图片到 WebDAV。"""
+        file_path = Path(file_path)
+        remote_id = self._get_remote_id(file_path)
+        remote_path = self._remote_id_to_path(remote_id)
+
+        self._ensure_remote_dirs(posixpath.dirname(remote_path))
+        with open(file_path, "rb") as file:
+            response = self._request("PUT", self._url_for_path(remote_path), data=file)
+
+        if response.status_code not in (200, 201, 204):
+            raise InvalidResponseError(
+                f"WebDAV 上传失败: HTTP {response.status_code} {response.text[:200]}"
+            )
+
+        category = posixpath.dirname(remote_id)
+        filename = posixpath.basename(remote_id)
+        return {
+            "id": remote_id,
+            "url": self._public_url_for_id(remote_id),
+            "filename": filename,
+            "category": "" if category == "." else category,
+            "size": file_path.stat().st_size,
+        }
+
+    def delete_image(self, image_hash: str) -> bool:
+        """从 WebDAV 删除图片。"""
+        remote_id = self._strip_base_path(image_hash)
+        remote_path = self._remote_id_to_path(remote_id)
+        response = self._request("DELETE", self._url_for_path(remote_path))
+        return response.status_code in (200, 204, 404)
+
+    def get_image_list(self) -> list[ImageInfo]:
+        """递归获取 WebDAV 上的图片列表。"""
+        self._ensure_remote_dirs(self.base_path)
+        images: list[ImageInfo] = []
+        self._collect_images(self.base_path, images)
+        return images
+
+    def download_image(self, image_info: dict[str, str], save_path: Path) -> bool:
+        """从 WebDAV 下载图片到本地。"""
+        remote_id = self._strip_base_path(image_info["id"])
+        remote_path = self._remote_id_to_path(remote_id)
+        response = self._request("GET", self._url_for_path(remote_path), stream=True)
+        if response.status_code != 200:
+            return False
+
+        save_path = Path(save_path)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(save_path, "wb") as file:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    file.write(chunk)
+        return save_path.exists() and save_path.stat().st_size > 0
+
+    def _collect_images(self, remote_dir: str, images: list[ImageInfo]) -> None:
+        response = self._propfind(remote_dir, depth=1)
+        entries = self._parse_propfind_response(response.text, remote_dir)
+
+        for entry in entries:
+            if entry["path"] == remote_dir:
+                continue
+            if entry["is_dir"]:
+                self._collect_images(entry["path"], images)
+                continue
+            filename = posixpath.basename(entry["path"])
+            if Path(filename).suffix.lower() not in self.SUPPORTED_EXTENSIONS:
+                continue
+
+            remote_id = self._strip_base_path(entry["path"])
+            category = posixpath.dirname(remote_id)
+            images.append(
+                {
+                    "id": remote_id,
+                    "url": self._public_url_for_id(remote_id),
+                    "filename": filename,
+                    "category": "" if category == "." else category,
+                    "size": entry["size"],
+                }
+            )
+
+    def _propfind(self, remote_path: str, depth: int = 1) -> requests.Response:
+        body = """<?xml version="1.0" encoding="utf-8" ?>
+<D:propfind xmlns:D="DAV:">
+  <D:prop>
+    <D:resourcetype />
+    <D:getcontentlength />
+  </D:prop>
+</D:propfind>"""
+        response = self._request(
+            "PROPFIND",
+            self._url_for_path(remote_path),
+            headers={"Depth": str(depth), "Content-Type": "application/xml"},
+            data=body.encode("utf-8"),
+        )
+        if response.status_code not in (207, 200):
+            raise InvalidResponseError(
+                f"WebDAV 列表失败: HTTP {response.status_code} {response.text[:200]}"
+            )
+        return response
+
+    def _parse_propfind_response(self, xml_text: str, requested_path: str) -> list[dict]:
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError as exc:
+            raise InvalidResponseError(f"WebDAV 返回 XML 解析失败: {exc}") from exc
+
+        entries = []
+        namespace = {"d": "DAV:"}
+        for response in root.findall("d:response", namespace):
+            href = response.findtext("d:href", default="", namespaces=namespace)
+            if not href:
+                continue
+
+            remote_path = self._path_from_href(href, requested_path)
+            resource_type = response.find(".//d:resourcetype", namespace)
+            is_dir = resource_type is not None and resource_type.find("d:collection", namespace) is not None
+            size_text = response.findtext(".//d:getcontentlength", default="0", namespaces=namespace)
+            entries.append(
+                {
+                    "path": remote_path,
+                    "is_dir": is_dir,
+                    "size": int(size_text) if str(size_text).isdigit() else 0,
+                }
+            )
+        return entries
+
+    def _ensure_remote_dirs(self, remote_dir: str) -> None:
+        parts = [part for part in remote_dir.split("/") if part]
+        current = ""
+        for part in parts:
+            current = part if not current else posixpath.join(current, part)
+            response = self._request("MKCOL", self._url_for_path(current))
+            if response.status_code not in (201, 405):
+                raise InvalidResponseError(
+                    f"WebDAV 创建目录失败: {current}, HTTP {response.status_code}"
+                )
+
+    def _request(self, method: str, url: str, **kwargs) -> requests.Response:
+        kwargs.setdefault("timeout", self.timeout)
+        kwargs.setdefault("verify", self.verify_ssl)
+        try:
+            response = self.session.request(method, url, **kwargs)
+        except requests.RequestException as exc:
+            raise NetworkError(f"WebDAV 请求失败: {exc}") from exc
+
+        if response.status_code in (401, 403):
+            raise AuthenticationError("WebDAV 认证失败，请检查用户名和密码")
+        return response
+
+    def _url_for_path(self, remote_path: str) -> str:
+        quoted_parts = [urllib.parse.quote(part) for part in remote_path.split("/") if part]
+        if not quoted_parts:
+            return self.base_url
+        return f"{self.base_url}/{'/'.join(quoted_parts)}"
+
+    def _public_url_for_id(self, remote_id: str) -> str:
+        if not self.public_url:
+            return self._url_for_path(self._remote_id_to_path(remote_id))
+        quoted_parts = [urllib.parse.quote(part) for part in remote_id.split("/") if part]
+        return f"{self.public_url}/{'/'.join(quoted_parts)}" if quoted_parts else self.public_url
+
+    def _get_remote_id(self, file_path: Path) -> str:
+        if self.local_dir:
+            try:
+                relative_path = file_path.relative_to(self.local_dir)
+                return self._normalize_path(str(relative_path))
+            except ValueError:
+                pass
+        return file_path.name
+
+    def _remote_id_to_path(self, remote_id: str) -> str:
+        normalized_id = self._normalize_path(remote_id)
+        return posixpath.join(self.base_path, normalized_id) if normalized_id else self.base_path
+
+    def _strip_base_path(self, remote_path: str) -> str:
+        normalized_path = self._normalize_path(remote_path)
+        if normalized_path == self.base_path:
+            return ""
+        prefix = f"{self.base_path}/" if self.base_path else ""
+        if prefix and normalized_path.startswith(prefix):
+            return normalized_path[len(prefix) :]
+        return normalized_path
+
+    def _path_from_href(self, href: str, requested_path: str) -> str:
+        parsed_href_path = urllib.parse.unquote(urllib.parse.urlparse(href).path).strip("/")
+        base_url_path = urllib.parse.unquote(urllib.parse.urlparse(self.base_url).path).strip("/")
+        if base_url_path and parsed_href_path.startswith(base_url_path):
+            parsed_href_path = parsed_href_path[len(base_url_path) :].strip("/")
+        if parsed_href_path:
+            return self._normalize_path(parsed_href_path)
+        return self._normalize_path(requested_path)
+
+    def _normalize_path(self, value: str | Path | None) -> str:
+        if value is None:
+            return ""
+        normalized = str(value).replace("\\", "/").strip("/")
+        return posixpath.normpath(normalized).strip("/") if normalized else ""
+
+    def _parse_bool(self, value) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() not in {"0", "false", "no", "off", "否"}
+        return bool(value)

--- a/main.py
+++ b/main.py
@@ -82,7 +82,13 @@ class MemeSender(Star):
 
         # 初始化图床同步客户端
         self.img_sync = None
-        image_host_type = self.config.get("image_host", "stardots")
+        image_host_type = self._get_image_host_type()
+        webdav_config = self._get_webdav_config()
+        if image_host_type == "stardots" and self._has_required_config(
+            webdav_config, ["url", "username", "password"]
+        ):
+            image_host_type = "webdav"
+            logger.info("检测到完整 WebDAV 配置，自动启用 WebDAV 图床。")
 
         if image_host_type == "stardots":
             stardots_config = self.config.get("image_host_config", {}).get(
@@ -122,6 +128,29 @@ class MemeSender(Star):
                 )
                 # 延迟日志记录，避免 logger 未初始化
                 self._r2_bucket_name = r2_config.get("bucket_name")
+        elif image_host_type == "webdav":
+            required_fields = ["url", "username", "password"]
+            if all(webdav_config.get(field) for field in required_fields):
+                if webdav_config.get("url"):
+                    webdav_config["url"] = str(webdav_config["url"]).rstrip("/")
+                if webdav_config.get("public_url"):
+                    webdav_config["public_url"] = str(
+                        webdav_config["public_url"]
+                    ).rstrip("/")
+                webdav_config["provider"] = "webdav"
+                self.img_sync = ImageSync(
+                    config=webdav_config, local_dir=MEMES_DIR, provider_type="webdav"
+                )
+                self._webdav_url = webdav_config.get("url")
+            else:
+                missing_fields = [
+                    field for field in required_fields if not webdav_config.get(field)
+                ]
+                logger.warning(
+                    "WebDAV 图床未初始化，缺少必要配置项: %s。当前已读取字段: %s",
+                    ", ".join(missing_fields),
+                    ", ".join(sorted(webdav_config.keys())) or "无",
+                )
 
         # 用于管理服务器
         self.webui_process = None
@@ -141,6 +170,9 @@ class MemeSender(Star):
         if hasattr(self, "_r2_bucket_name"):
             logger.info(f"Cloudflare R2 图床已初始化: {self._r2_bucket_name}")
             delattr(self, "_r2_bucket_name")
+        if hasattr(self, "_webdav_url"):
+            logger.info(f"WebDAV 图床已初始化: {self._webdav_url}")
+            delattr(self, "_webdav_url")
 
         # 处理人格
         self.prompt_head = self.config.get("prompt").get("prompt_head")
@@ -194,6 +226,54 @@ class MemeSender(Star):
         """
         pass
 
+    def _get_image_host_type(self) -> str:
+        """读取图床类型，兼容不同配置保存格式。"""
+        image_host = self.config.get("image_host", "stardots")
+        if isinstance(image_host, dict):
+            image_host = image_host.get("name") or image_host.get("value") or image_host.get(
+                "type", "stardots"
+            )
+        return str(image_host or "stardots").strip().lower()
+
+    def _get_nested_config(self, *keys: str) -> dict:
+        current = self.config
+        for key in keys:
+            if not isinstance(current, dict):
+                return {}
+            current = current.get(key, {})
+        return current if isinstance(current, dict) else {}
+
+    def _has_required_config(self, config: dict, required_fields: list[str]) -> bool:
+        return all(config.get(field) not in (None, "") for field in required_fields)
+
+    def _get_webdav_config(self) -> dict:
+        """读取 WebDAV 配置，兼容嵌套、扁平和常见字段别名。"""
+        webdav_config = dict(self._get_nested_config("image_host_config", "webdav"))
+
+        if not webdav_config:
+            webdav_config = dict(self._get_nested_config("webdav"))
+
+        aliases = {
+            "url": ["webdav_url", "endpoint", "base_url", "host"],
+            "username": ["webdav_username", "user", "account"],
+            "password": ["webdav_password", "pass", "token", "access_token"],
+            "base_path": ["webdav_base_path", "path", "root_path", "remote_path"],
+            "public_url": ["webdav_public_url", "cdn_url"],
+            "verify_ssl": ["webdav_verify_ssl", "ssl_verify"],
+            "timeout": ["webdav_timeout"],
+        }
+
+        for target_key, alias_keys in aliases.items():
+            if webdav_config.get(target_key) not in (None, ""):
+                continue
+            for alias_key in alias_keys:
+                value = webdav_config.get(alias_key, self.config.get(alias_key))
+                if value not in (None, ""):
+                    webdav_config[target_key] = value
+                    break
+
+        return webdav_config
+
     @filter.permission_type(filter.PermissionType.ADMIN)
     @meme_manager.command("开启管理后台")
     async def start_webui(self, event: AstrMessageEvent):
@@ -228,7 +308,10 @@ class MemeSender(Star):
                     raise RuntimeError(f"端口 {self.server_port} 仍被占用")
 
             config_for_server = {
-                "img_sync": self.img_sync,
+                "img_sync_config": self.img_sync.config if self.img_sync else None,
+                "img_sync_provider_type": self.img_sync.provider_type
+                if self.img_sync
+                else None,
                 "category_manager": self.category_manager,
                 "webui_port": self.server_port,
                 "server_key": self.server_key,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ tqdm
 boto3
 botocore
 pillow
+requests

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -337,7 +337,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const payload = await parseResponsePayload(response).catch(() => ({}));
 
     if (!response.ok) {
-      const error = new Error(payload.message || defaultErrorMessage);
+      const error = new Error(payload.message || payload.error || defaultErrorMessage);
       error.status = response.status;
       error.code = payload.code || null;
       error.payload = payload;

--- a/webui.py
+++ b/webui.py
@@ -16,6 +16,7 @@ from quart import (
 
 from .backend.api import api
 from .config import MEMES_DIR
+from .image_host.img_sync import ImageSync
 
 
 class ServerState:
@@ -36,6 +37,20 @@ app.register_blueprint(api, url_prefix="/api")
 
 SERVER_LOGIN_KEY = None
 _current_server = None
+
+
+def _build_img_sync(config):
+    """在 WebUI 进程内重建图床同步客户端，避免跨进程复用连接对象。"""
+    if not config:
+        return False
+
+    existing_img_sync = config.get("img_sync")
+    img_sync_config = config.get("img_sync_config")
+    provider_type = config.get("img_sync_provider_type")
+
+    if img_sync_config and provider_type:
+        return ImageSync(img_sync_config, MEMES_DIR, provider_type)
+    return existing_img_sync or False
 
 
 @app.route("/health", methods=["GET"])
@@ -101,7 +116,7 @@ async def start_server(config=None):
     # 配置应用
     app.secret_key = os.urandom(16)
     app.config["PLUGIN_CONFIG"] = {
-        "img_sync": config.get("img_sync", False),
+        "img_sync": _build_img_sync(config),
         "category_manager": config.get("category_manager"),
         "webui_port": port,
     }
@@ -127,7 +142,7 @@ async def create_app(config=None):
 
     if config is not None and hasattr(config, "get"):
         app.config["PLUGIN_CONFIG"] = {
-            "img_sync": config.get("img_sync"),
+            "img_sync": _build_img_sync(config),
             "category_manager": config.get("category_manager"),
             "webui_port": config.get("webui_port", 5000),
         }


### PR DESCRIPTION
感谢这个插件让我的猫娘可以开启无限制表情包！我平时更习惯使用 WebDAV 存储，所以尝试基于现有图床接口增加了 WebDAV provider，希望能补充 NAS / 自建存储等使用场景。

## 变更说明

本 PR 为表情包管理器新增 WebDAV 图床/云存储支持，可用于将本地表情包同步到兼容 WebDAV 的存储服务。

适用场景包括：

- NAS / 群晖
- Alist / OpenList
- Nextcloud
- 坚果云
- 123 云盘
- 其他兼容 WebDAV 的存储服务

## 主要改动

- 新增 `WebDAVProvider`，实现现有 `ImageHostInterface`
- 支持 WebDAV 上传、下载、递归列表、删除和自动创建远端目录
- 在图床配置中新增 `webdav` 选项
- WebUI 图床状态支持显示 WebDAV
- 同步子进程支持识别 WebDAV 配置
- WebUI 子进程中会重建图床同步客户端，避免跨进程复用连接对象
- README 增加 WebDAV 配置说明

## WebDAV 配置项说明

- `url`：WebDAV 服务根地址，用于上传、下载、列目录和删除文件，例如 `https://webdav.123pan.cn/webdav`
- `username`：WebDAV 登录用户名
- `password`：WebDAV 登录密码、应用密码或访问令牌
- `base_path`：WebDAV 远端存储目录，插件会将表情包保存到该目录下，默认 `memes`
- `public_url`：公开访问根地址，可选；用于生成图片访问 URL，例如 CDN、反代或公开目录地址。如果不填写，插件仍可进行同步，但生成的 URL 可能需要认证后才能访问
- `verify_ssl`：是否校验 HTTPS 证书；自签名证书或内网 WebDAV 服务可关闭
- `timeout`：WebDAV 请求超时时间，单位为秒，用于上传、下载、列目录、删除等请求

## 兼容性

- 保持与现有图床同步接口兼容
- 不影响现有 Stardots 和 Cloudflare R2 配置
- WebDAV 为可选图床类型，若未配置 WebDAV，不会改变原有行为

## 验证

已进行基础验证：

- `_conf_schema.json` 可正常解析
- 相关 Python 文件通过语法检查
- WebDAV provider 返回字段兼容现有同步逻辑

## 说明

WebDAV 服务之间实现可能存在差异，例如路径编码、目录创建、SSL 证书、公开外链等行为，目前仅测试 123 云盘和坚果云。

本实现默认将 WebDAV 作为同步/备份型图床使用；如果用户配置 `public_url`，则可生成公开访问地址。