### PR TITLE
feat: distinguish semantic meme packs in catalog

### DIFF
--- a/pages/catalog/index.html
+++ b/pages/catalog/index.html
@@ -15,7 +15,7 @@
       <div>
         <p class="eyebrow">Meme Pack Catalog</p>
         <h1><i class="fas fa-store icon"></i>表情包资源广场</h1>
-        <p class="subtitle">下载官方与社区表情包，支持缓存索引与一键安装。</p>
+        <p class="subtitle">下载官方与社区表情包，支持新版语义包与传统包。</p>
       </div>
       <div class="nav-actions">
         <a
@@ -34,6 +34,27 @@
     </header>
 
     <main class="layout">
+      <section class="format-guide" aria-label="表情包版本说明">
+        <div class="format-guide-item semantic">
+          <span class="format-guide-icon">
+            <i class="fas fa-wand-magic-sparkles"></i>
+          </span>
+          <span>
+            <strong>新版语义包</strong>
+            <small>携带可复用语义描述，向量会按本机模型建立</small>
+          </span>
+        </div>
+        <div class="format-guide-item classic">
+          <span class="format-guide-icon">
+            <i class="fas fa-box-archive"></i>
+          </span>
+          <span>
+            <strong>传统包</strong>
+            <small>沿用分类描述，无需配置向量模型</small>
+          </span>
+        </div>
+      </section>
+
       <section class="panel catalog-list official-zone">
         <div class="panel-header">
           <h2><i class="fas fa-crown icon"></i>官方包</h2>
@@ -56,6 +77,10 @@
 
       <section class="panel manual-source">
         <h2><i class="fab fa-github icon"></i>手动 GitHub 来源安装</h2>
+        <p class="manual-source-hint">
+          <i class="fas fa-circle-info"></i>
+          新版与传统包均可安装；未收录来源会在安装时自动识别结构。
+        </p>
         <div class="triple-grid">
           <div class="field-row">
             <label for="source-repo-input">Repo</label>

--- a/pages/catalog/script.js
+++ b/pages/catalog/script.js
@@ -179,6 +179,56 @@ async function initCatalogPage() {
     return packId.startsWith("official-") || tags.includes("official");
   }
 
+  function readPackFormat(pack) {
+    // 现有索引可直接使用 semantic/v2 标签；同时兼容未来的显式能力字段。
+    const tags = new Set(
+      (Array.isArray(pack?.tags) ? pack.tags : []).map((tag) =>
+        String(tag || "")
+          .trim()
+          .toLowerCase(),
+      ),
+    );
+    const features =
+      pack?.features && typeof pack.features === "object"
+        ? pack.features
+        : {};
+    const protocol =
+      pack?.protocol && typeof pack.protocol === "object"
+        ? pack.protocol
+        : {};
+    const formatVersion = Number(
+      pack?.format_version || protocol?.format_version || 0,
+    );
+    const hasSemanticMetadata = Boolean(
+      features.semantic_metadata ||
+        pack?.semantic_metadata ||
+        tags.has("semantic") ||
+        tags.has("semantic-v2") ||
+        tags.has("语义包"),
+    );
+    const isNewFormat = Boolean(
+      hasSemanticMetadata ||
+        formatVersion >= 2 ||
+        tags.has("v2") ||
+        tags.has("new-format"),
+    );
+
+    if (isNewFormat) {
+      return {
+        kind: "semantic",
+        badge: hasSemanticMetadata ? "新版语义包" : "新版包",
+        note: hasSemanticMetadata
+          ? "包含可复用语义描述；不会分发本机向量，安装后可按当前向量模型重建。"
+          : "采用新版包结构，兼容语义描述与本机向量重建流程。",
+      };
+    }
+    return {
+      kind: "classic",
+      badge: "传统包",
+      note: "使用传统分类描述，无需配置向量模型，安装后继续使用分类匹配。",
+    };
+  }
+
   function normalizeGithubSubpath(subpath) {
     return String(subpath || "")
       .trim()
@@ -271,8 +321,11 @@ async function initCatalogPage() {
   }
 
   function createPackCard(pack, { forceOfficial = false } = {}) {
+    const format = readPackFormat(pack);
     const card = document.createElement("article");
-    card.className = `pack-card${forceOfficial ? " official" : ""}`;
+    card.className = `pack-card ${format.kind}-pack${
+      forceOfficial ? " official" : ""
+    }`;
 
     const isInstalled = installedPackIds.has(String(pack.id || "").trim());
     const tags = Array.isArray(pack.tags) ? pack.tags : [];
@@ -308,6 +361,18 @@ async function initCatalogPage() {
     const tagRow = document.createElement("div");
     tagRow.className = "tag-row";
 
+    const formatTag = document.createElement("span");
+    formatTag.className = `tag format-tag ${format.kind}`;
+    const formatTagIcon = document.createElement("i");
+    formatTagIcon.className =
+      format.kind === "semantic"
+        ? "fas fa-wand-magic-sparkles"
+        : "fas fa-box-archive";
+    const formatTagText = document.createElement("span");
+    formatTagText.textContent = format.badge;
+    formatTag.append(formatTagIcon, formatTagText);
+    tagRow.appendChild(formatTag);
+
     const verifyTag = document.createElement("span");
     verifyTag.className = `tag ${pack.verified ? "verified" : "unverified"}`;
     verifyTag.textContent = pack.verified ? "已验证" : "未验证";
@@ -338,6 +403,17 @@ async function initCatalogPage() {
     desc.className = "pack-desc";
     desc.textContent = pack.description || "暂无描述";
 
+    const formatNote = document.createElement("p");
+    formatNote.className = `pack-format-note ${format.kind}`;
+    const formatNoteIcon = document.createElement("i");
+    formatNoteIcon.className =
+      format.kind === "semantic"
+        ? "fas fa-cubes-stacked"
+        : "fas fa-layer-group";
+    const formatNoteText = document.createElement("span");
+    formatNoteText.textContent = format.note;
+    formatNote.append(formatNoteIcon, formatNoteText);
+
     const meta = document.createElement("div");
     meta.className = "pack-meta";
     meta.innerHTML = `
@@ -350,6 +426,7 @@ async function initCatalogPage() {
     card.appendChild(titleRow);
     card.appendChild(tagRow);
     card.appendChild(desc);
+    card.appendChild(formatNote);
     card.appendChild(meta);
     return card;
   }

--- a/pages/catalog/style.css
+++ b/pages/catalog/style.css
@@ -112,6 +112,67 @@ h1 {
   grid-column: span 12;
 }
 
+.format-guide {
+  grid-column: span 12;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.format-guide-item {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 11px;
+  padding: 12px 14px;
+  border: 1px solid rgba(214, 229, 225, 0.94);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 8px 20px rgba(20, 56, 59, 0.06);
+}
+
+.format-guide-item.semantic {
+  border-color: rgba(31, 111, 176, 0.24);
+  background: linear-gradient(135deg, #eef8ff, #f1fbf6);
+}
+
+.format-guide-item.classic {
+  background: linear-gradient(135deg, #f8fafc, #ffffff);
+}
+
+.format-guide-icon {
+  display: inline-flex;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: #dff2fb;
+  color: var(--accent);
+}
+
+.format-guide-item.classic .format-guide-icon {
+  background: #edf2f5;
+  color: #60737a;
+}
+
+.format-guide-item strong,
+.format-guide-item small {
+  display: block;
+}
+
+.format-guide-item strong {
+  margin-bottom: 3px;
+  font-size: 14px;
+}
+
+.format-guide-item small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .official-zone {
   border-color: #ecd8a2;
   background: linear-gradient(180deg, #fffdf6 0%, #ffffff 100%);
@@ -131,6 +192,18 @@ h1 {
   display: grid;
   gap: 8px;
   margin-bottom: 12px;
+}
+
+.manual-source-hint {
+  margin: -4px 0 14px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.manual-source-hint i {
+  margin-right: 5px;
+  color: var(--accent);
 }
 
 .field-row label {
@@ -301,6 +374,17 @@ button:disabled {
   transition: transform 0.2s ease;
 }
 
+.pack-card.semantic-pack {
+  border-color: rgba(31, 111, 176, 0.28);
+  background:
+    linear-gradient(180deg, rgba(238, 248, 255, 0.92), #ffffff 46%);
+  box-shadow: 0 12px 26px rgba(31, 111, 176, 0.09);
+}
+
+.pack-card.classic-pack {
+  border-color: rgba(148, 163, 184, 0.34);
+}
+
 .pack-cover {
   width: 100%;
   aspect-ratio: 16 / 9;
@@ -350,6 +434,12 @@ button:disabled {
   background: linear-gradient(180deg, #fff9ea 0%, #fff 100%);
 }
 
+.pack-card.official.semantic-pack {
+  border-color: rgba(54, 142, 124, 0.38);
+  background:
+    linear-gradient(135deg, rgba(255, 249, 234, 0.96), rgba(237, 251, 246, 0.96));
+}
+
 .pack-title-row {
   display: flex;
   justify-content: space-between;
@@ -395,11 +485,56 @@ button:disabled {
   color: #2f5f9e;
 }
 
+.tag.format-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-weight: 700;
+}
+
+.tag.format-tag.semantic {
+  background: #e3f4ff;
+  color: #17649b;
+}
+
+.tag.format-tag.classic {
+  background: #edf2f5;
+  color: #52676e;
+}
+
 .pack-desc {
   margin: 0;
   color: #33483e;
   font-size: 13px;
   line-height: 1.45;
+}
+
+.pack-format-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
+  padding: 9px 10px;
+  border-radius: 10px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.pack-format-note.semantic {
+  border: 1px solid rgba(31, 111, 176, 0.16);
+  background: #f0f8fd;
+  color: #315d77;
+}
+
+.pack-format-note.classic {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: #f7f9fa;
+  color: #5a6b71;
+}
+
+.pack-format-note i {
+  margin-top: 2px;
+  flex: 0 0 auto;
 }
 
 .pack-meta {
@@ -431,6 +566,10 @@ button:disabled {
 }
 
 @media (max-width: 960px) {
+  .format-guide {
+    grid-template-columns: 1fr;
+  }
+
   .triple-grid {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## 依赖关系

- 产品功能上依赖 #105 提供的新版表情包导入与本机向量重建能力。
- 本分支从 main 独立创建，因此代码差异只包含资源广场页面，不会夹带 #104 或 #105 的实现代码。

## 概要

- 在资源广场中区分新版语义包与传统包。
- 根据语义能力字段、格式版本或兼容标签显示对应标识。
- 说明语义描述可以随包复用，但向量需要按本机模型建立。
- 增加移动端自适应样式和手动来源安装提示。

## 变更边界

- 本 PR 只修改 astrbot_plugin_meme_manager 内的资源广场展示。
- 本 PR 没有修改表情包收集器插件，也没有修改其他表情包来源端或来源仓库。
- 本 PR 不负责生成新版表情包，只负责识别资源市场索引已有或未来提供的格式信息并展示标识。

## 验证

- 仅修改 pages/catalog 下的 3 个前端文件。
- JavaScript 语法检查通过。
- Git 差异格式检查通过。