### PR TITLE
feat: [3/3] 在资源市场区分语义包和传统包

### DIFF
--- a/pages/catalog/index.html
+++ b/pages/catalog/index.html
@@ -15,7 +15,7 @@
       <div>
         <p class="eyebrow">Meme Pack Catalog</p>
         <h1><i class="fas fa-store icon"></i>表情包资源广场</h1>
-        <p class="subtitle">下载官方与社区表情包，支持缓存索引与一键安装。</p>
+        <p class="subtitle">下载官方与社区表情包，支持新版语义包与传统包。</p>
       </div>
       <div class="nav-actions">
         <a
@@ -34,6 +34,27 @@
     </header>
 
     <main class="layout">
+      <section class="format-guide" aria-label="表情包版本说明">
+        <div class="format-guide-item semantic">
+          <span class="format-guide-icon">
+            <i class="fas fa-wand-magic-sparkles"></i>
+          </span>
+          <span>
+            <strong>新版语义包</strong>
+            <small>携带可复用语义描述，向量会按本机模型建立</small>
+          </span>
+        </div>
+        <div class="format-guide-item classic">
+          <span class="format-guide-icon">
+            <i class="fas fa-box-archive"></i>
+          </span>
+          <span>
+            <strong>传统包</strong>
+            <small>沿用分类描述，无需配置向量模型</small>
+          </span>
+        </div>
+      </section>
+
       <section class="panel catalog-list official-zone">
         <div class="panel-header">
           <h2><i class="fas fa-crown icon"></i>官方包</h2>
@@ -56,6 +77,10 @@
 
       <section class="panel manual-source">
         <h2><i class="fab fa-github icon"></i>手动 GitHub 来源安装</h2>
+        <p class="manual-source-hint">
+          <i class="fas fa-circle-info"></i>
+          新版与传统包均可安装；未收录来源会在安装时自动识别结构。
+        </p>
         <div class="triple-grid">
           <div class="field-row">
             <label for="source-repo-input">Repo</label>

--- a/pages/catalog/script.js
+++ b/pages/catalog/script.js
@@ -179,6 +179,56 @@ async function initCatalogPage() {
     return packId.startsWith("official-") || tags.includes("official");
   }
 
+  function readPackFormat(pack) {
+    // 现有索引可直接使用 semantic/v2 标签；同时兼容未来的显式能力字段。
+    const tags = new Set(
+      (Array.isArray(pack?.tags) ? pack.tags : []).map((tag) =>
+        String(tag || "")
+          .trim()
+          .toLowerCase(),
+      ),
+    );
+    const features =
+      pack?.features && typeof pack.features === "object"
+        ? pack.features
+        : {};
+    const protocol =
+      pack?.protocol && typeof pack.protocol === "object"
+        ? pack.protocol
+        : {};
+    const formatVersion = Number(
+      pack?.format_version || protocol?.format_version || 0,
+    );
+    const hasSemanticMetadata = Boolean(
+      features.semantic_metadata ||
+        pack?.semantic_metadata ||
+        tags.has("semantic") ||
+        tags.has("semantic-v2") ||
+        tags.has("语义包"),
+    );
+    const isNewFormat = Boolean(
+      hasSemanticMetadata ||
+        formatVersion >= 2 ||
+        tags.has("v2") ||
+        tags.has("new-format"),
+    );
+
+    if (isNewFormat) {
+      return {
+        kind: "semantic",
+        badge: hasSemanticMetadata ? "新版语义包" : "新版包",
+        note: hasSemanticMetadata
+          ? "包含可复用语义描述；不会分发本机向量，安装后可按当前向量模型重建。"
+          : "采用新版包结构，兼容语义描述与本机向量重建流程。",
+      };
+    }
+    return {
+      kind: "classic",
+      badge: "传统包",
+      note: "使用传统分类描述，无需配置向量模型，安装后继续使用分类匹配。",
+    };
+  }
+
   function normalizeGithubSubpath(subpath) {
     return String(subpath || "")
       .trim()
@@ -271,8 +321,11 @@ async function initCatalogPage() {
   }
 
   function createPackCard(pack, { forceOfficial = false } = {}) {
+    const format = readPackFormat(pack);
     const card = document.createElement("article");
-    card.className = `pack-card${forceOfficial ? " official" : ""}`;
+    card.className = `pack-card ${format.kind}-pack${
+      forceOfficial ? " official" : ""
+    }`;
 
     const isInstalled = installedPackIds.has(String(pack.id || "").trim());
     const tags = Array.isArray(pack.tags) ? pack.tags : [];
@@ -308,6 +361,18 @@ async function initCatalogPage() {
     const tagRow = document.createElement("div");
     tagRow.className = "tag-row";
 
+    const formatTag = document.createElement("span");
+    formatTag.className = `tag format-tag ${format.kind}`;
+    const formatTagIcon = document.createElement("i");
+    formatTagIcon.className =
+      format.kind === "semantic"
+        ? "fas fa-wand-magic-sparkles"
+        : "fas fa-box-archive";
+    const formatTagText = document.createElement("span");
+    formatTagText.textContent = format.badge;
+    formatTag.append(formatTagIcon, formatTagText);
+    tagRow.appendChild(formatTag);
+
     const verifyTag = document.createElement("span");
     verifyTag.className = `tag ${pack.verified ? "verified" : "unverified"}`;
     verifyTag.textContent = pack.verified ? "已验证" : "未验证";
@@ -338,6 +403,17 @@ async function initCatalogPage() {
     desc.className = "pack-desc";
     desc.textContent = pack.description || "暂无描述";
 
+    const formatNote = document.createElement("p");
+    formatNote.className = `pack-format-note ${format.kind}`;
+    const formatNoteIcon = document.createElement("i");
+    formatNoteIcon.className =
+      format.kind === "semantic"
+        ? "fas fa-cubes-stacked"
+        : "fas fa-layer-group";
+    const formatNoteText = document.createElement("span");
+    formatNoteText.textContent = format.note;
+    formatNote.append(formatNoteIcon, formatNoteText);
+
     const meta = document.createElement("div");
     meta.className = "pack-meta";
     meta.innerHTML = `
@@ -350,6 +426,7 @@ async function initCatalogPage() {
     card.appendChild(titleRow);
     card.appendChild(tagRow);
     card.appendChild(desc);
+    card.appendChild(formatNote);
     card.appendChild(meta);
     return card;
   }

--- a/pages/catalog/style.css
+++ b/pages/catalog/style.css
@@ -112,6 +112,67 @@ h1 {
   grid-column: span 12;
 }
 
+.format-guide {
+  grid-column: span 12;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.format-guide-item {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 11px;
+  padding: 12px 14px;
+  border: 1px solid rgba(214, 229, 225, 0.94);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 8px 20px rgba(20, 56, 59, 0.06);
+}
+
+.format-guide-item.semantic {
+  border-color: rgba(31, 111, 176, 0.24);
+  background: linear-gradient(135deg, #eef8ff, #f1fbf6);
+}
+
+.format-guide-item.classic {
+  background: linear-gradient(135deg, #f8fafc, #ffffff);
+}
+
+.format-guide-icon {
+  display: inline-flex;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: #dff2fb;
+  color: var(--accent);
+}
+
+.format-guide-item.classic .format-guide-icon {
+  background: #edf2f5;
+  color: #60737a;
+}
+
+.format-guide-item strong,
+.format-guide-item small {
+  display: block;
+}
+
+.format-guide-item strong {
+  margin-bottom: 3px;
+  font-size: 14px;
+}
+
+.format-guide-item small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .official-zone {
   border-color: #ecd8a2;
   background: linear-gradient(180deg, #fffdf6 0%, #ffffff 100%);
@@ -131,6 +192,18 @@ h1 {
   display: grid;
   gap: 8px;
   margin-bottom: 12px;
+}
+
+.manual-source-hint {
+  margin: -4px 0 14px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.manual-source-hint i {
+  margin-right: 5px;
+  color: var(--accent);
 }
 
 .field-row label {
@@ -301,6 +374,17 @@ button:disabled {
   transition: transform 0.2s ease;
 }
 
+.pack-card.semantic-pack {
+  border-color: rgba(31, 111, 176, 0.28);
+  background:
+    linear-gradient(180deg, rgba(238, 248, 255, 0.92), #ffffff 46%);
+  box-shadow: 0 12px 26px rgba(31, 111, 176, 0.09);
+}
+
+.pack-card.classic-pack {
+  border-color: rgba(148, 163, 184, 0.34);
+}
+
 .pack-cover {
   width: 100%;
   aspect-ratio: 16 / 9;
@@ -350,6 +434,12 @@ button:disabled {
   background: linear-gradient(180deg, #fff9ea 0%, #fff 100%);
 }
 
+.pack-card.official.semantic-pack {
+  border-color: rgba(54, 142, 124, 0.38);
+  background:
+    linear-gradient(135deg, rgba(255, 249, 234, 0.96), rgba(237, 251, 246, 0.96));
+}
+
 .pack-title-row {
   display: flex;
   justify-content: space-between;
@@ -395,11 +485,56 @@ button:disabled {
   color: #2f5f9e;
 }
 
+.tag.format-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-weight: 700;
+}
+
+.tag.format-tag.semantic {
+  background: #e3f4ff;
+  color: #17649b;
+}
+
+.tag.format-tag.classic {
+  background: #edf2f5;
+  color: #52676e;
+}
+
 .pack-desc {
   margin: 0;
   color: #33483e;
   font-size: 13px;
   line-height: 1.45;
+}
+
+.pack-format-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
+  padding: 9px 10px;
+  border-radius: 10px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.pack-format-note.semantic {
+  border: 1px solid rgba(31, 111, 176, 0.16);
+  background: #f0f8fd;
+  color: #315d77;
+}
+
+.pack-format-note.classic {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: #f7f9fa;
+  color: #5a6b71;
+}
+
+.pack-format-note i {
+  margin-top: 2px;
+  flex: 0 0 auto;
 }
 
 .pack-meta {
@@ -431,6 +566,10 @@ button:disabled {
 }
 
 @media (max-width: 960px) {
+  .format-guide {
+    grid-template-columns: 1fr;
+  }
+
   .triple-grid {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## 合并顺序

> **这是整组改动的第 3 个 PR，请最后合并。**
>
> 请按 **#107 → #108 → 本 PR** 的顺序处理。先完成语义功能和图包传输兼容，再展示资源市场标识，用户看到的说明才会与实际能力一致。

## 这个 PR 做了什么

这个 PR 只修改插件实现端的资源市场页面，让用户在安装前就能看懂一个图包属于新版语义包还是传统分类包。

- 资源市场顶部增加新版语义包和传统包的简单说明。
- 每张图包卡片增加醒目的类型标识。
- 新版语义包说明会提示：语义描述可以复用，但本机向量需要按照当前机器的模型建立。
- 传统包说明会提示：不需要配置向量模型，仍然使用原来的分类匹配。
- 手动填写 GitHub 来源时说明两种图包都可以安装，并由实现端自动识别结构。
- 页面同时兼容索引中的标签、能力字段和格式版本字段，便于后续逐步升级资源索引。
- 手机和窄屏页面也会正常显示两种类型说明。

## 特别说明

- **本 PR 只修改实现端和资源市场中的显示标识。**
- **没有修改表情包来源插件。**
- **没有修改表情包收集器插件。**
- 没有改变图包发布、收集或上传来源的工作方式。
- 没有修改语义生成、向量建立、导入导出和运行时选图逻辑。

## 涉及文件

仅修改以下 3 个资源市场前端文件：

- `pages/catalog/index.html`
- `pages/catalog/script.js`
- `pages/catalog/style.css`

## 验证结果

- 资源市场 JavaScript 语法检查通过
- Git 差异格式检查通过
- 与上游 `main` 比较仅包含上述 3 个资源市场页面文件

## 合并提醒

请不要在 #107 和 #108 之前单独合并本 PR。提前显示新版语义包标识，会让资源市场页面先于实际导入和兼容能力上线。

## 相关 PR

- **第 1 个：#107 语义功能与旧版兼容**
- **第 2 个：#108 图包导入导出、备份与兼容恢复**
- **第 3 个：#109 当前 PR，资源市场区分语义包和传统包**

请严格按 **#107 → #108 → #109** 的顺序合并。