### PR TITLE
fix(emotion): ignore image refs and URIs during loose matching

### DIFF
--- a/backend/text_safety.py
+++ b/backend/text_safety.py
@@ -1,0 +1,242 @@
+"""Pure text-safety helpers for response cleanup and emotion matching."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import unquote, urlsplit
+
+
+_IMAGE_SUFFIXES = (".jpg", ".jpeg", ".png", ".gif", ".webp")
+_IMAGE_REF_LINE_RE = re.compile(
+    r"^ {0,3}\[image[ \t]+ref[ \t]+[1-9]\d*\]"
+    r"(?:[ \t]*:[ \t]*|[ \t]+)(?P<reference>.*\S)[ \t]*$",
+    re.IGNORECASE,
+)
+_FENCE_RE = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})")
+_DATA_IMAGE_RE = re.compile(
+    r"^data:image/(?:jpe?g|png|gif|webp);base64,[a-z0-9+/=_-]+$",
+    re.IGNORECASE,
+)
+_BASE64_IMAGE_RE = re.compile(r"^base64://[a-z0-9+/=_-]+$", re.IGNORECASE)
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[a-z]:[\\/]", re.IGNORECASE)
+_UNC_PATH_RE = re.compile(r"^(?:\\\\|//)[^\\/]+[\\/][^\\/]+")
+_MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]\r\n]*\]\([^)\r\n]*\)")
+_INLINE_CODE_RE = re.compile(r"(?P<fence>`+)[^\r\n]*?(?P=fence)")
+_URI_RE = re.compile(
+    r"(?:file|https?|data|base64):[^\s,，。！？；：、]+",
+    re.IGNORECASE,
+)
+_REFERENCE_TOKEN_RE = re.compile(r"[^\s,;!?，。！？；：、]+")
+_REFERENCE_SCHEME_RE = re.compile(r"(?:file|https?|data|base64):", re.IGNORECASE)
+_DOMAIN_RE = re.compile(
+    r"(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,63}",
+    re.IGNORECASE,
+)
+
+
+def _unwrap_reference(value: str) -> str:
+    reference = value.strip()
+    if reference.startswith("<") and reference.endswith(">"):
+        return reference[1:-1].strip()
+    return reference
+
+
+def _has_supported_image_suffix(value: str) -> bool:
+    return unquote(value).lower().endswith(_IMAGE_SUFFIXES)
+
+
+def _is_supported_image_reference(value: str) -> bool:
+    reference = _unwrap_reference(value)
+    if not reference:
+        return False
+
+    if _DATA_IMAGE_RE.fullmatch(reference) or _BASE64_IMAGE_RE.fullmatch(reference):
+        return True
+
+    try:
+        parsed = urlsplit(reference)
+    except ValueError:
+        return False
+    scheme = parsed.scheme.lower()
+    if scheme in {"http", "https"}:
+        return bool(parsed.netloc) and _has_supported_image_suffix(parsed.path)
+    if scheme == "file":
+        file_target = reference[len(parsed.scheme) + 1 :]
+        is_absolute = bool(parsed.netloc) or file_target.startswith("/")
+        return is_absolute and _has_supported_image_suffix(parsed.path)
+
+    decoded_reference = unquote(reference)
+    is_absolute_path = (
+        decoded_reference.startswith("/")
+        or bool(_WINDOWS_ABSOLUTE_PATH_RE.match(decoded_reference))
+        or bool(_UNC_PATH_RE.match(decoded_reference))
+    )
+    return is_absolute_path and _has_supported_image_suffix(decoded_reference)
+
+
+def _is_plugin_owned_file_image_reference(line_body: str) -> bool:
+    leading_spaces = len(line_body) - len(line_body.lstrip(" "))
+    if leading_spaces > 3 or line_body[leading_spaces:].startswith("\t"):
+        return False
+
+    reference = _unwrap_reference(line_body)
+    try:
+        parsed = urlsplit(reference)
+    except ValueError:
+        return False
+    if parsed.scheme.lower() != "file" or not _is_supported_image_reference(reference):
+        return False
+
+    path_parts = [
+        part.casefold()
+        for part in unquote(parsed.path).replace("\\", "/").split("/")
+        if part
+    ]
+    return any(
+        path_parts[index : index + 2] == ["plugin_data", "meme_manager"]
+        for index in range(len(path_parts) - 1)
+    )
+
+
+def strip_internal_image_ref_lines(text: str) -> str:
+    """Remove standalone machine-generated image-reference lines.
+
+    A numbered marker may use any supported image reference. An unmarked line
+    is removed only when it is a local ``file:`` image URI under this plugin's
+    ``plugin_data/meme_manager`` directory. Markdown code remains untouched.
+    """
+
+    if not text:
+        return text
+
+    kept_lines: list[str] = []
+    active_fence: tuple[str, int] | None = None
+
+    for line in text.splitlines(keepends=True):
+        line_body = line.rstrip("\r\n")
+        fence_match = _FENCE_RE.match(line_body)
+
+        if active_fence is not None:
+            kept_lines.append(line)
+            if fence_match:
+                fence = fence_match.group("fence")
+                is_closing_fence = not line_body[fence_match.end() :].strip()
+                if (
+                    fence[0] == active_fence[0]
+                    and len(fence) >= active_fence[1]
+                    and is_closing_fence
+                ):
+                    active_fence = None
+            continue
+
+        if fence_match:
+            fence = fence_match.group("fence")
+            active_fence = (fence[0], len(fence))
+            kept_lines.append(line)
+            continue
+
+        marker_match = _IMAGE_REF_LINE_RE.fullmatch(line_body)
+        is_marked_reference = marker_match and _is_supported_image_reference(
+            marker_match.group("reference")
+        )
+        if is_marked_reference or _is_plugin_owned_file_image_reference(line_body):
+            continue
+
+        kept_lines.append(line)
+
+    return "".join(kept_lines)
+
+
+def _token_is_reference(token: str) -> bool:
+    if "/" in token or "\\" in token:
+        return True
+    if _REFERENCE_SCHEME_RE.search(token) or _DOMAIN_RE.search(token):
+        return True
+
+    filename_token = token.strip("\"'`<>()[]{}，。！？；：、,.!?;:")
+    return _has_supported_image_suffix(filename_token)
+
+
+def _merge_spans(spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    if not spans:
+        return []
+
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            previous_start, previous_end = merged[-1]
+            merged[-1] = (previous_start, max(previous_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _protected_reference_spans(text: str) -> list[tuple[int, int]]:
+    spans = [
+        match.span()
+        for pattern in (_MARKDOWN_LINK_RE, _INLINE_CODE_RE, _URI_RE)
+        for match in pattern.finditer(text)
+    ]
+
+    active_fence: tuple[str, int] | None = None
+    offset = 0
+    for line in text.splitlines(keepends=True):
+        line_body = line.rstrip("\r\n")
+        fence_match = _FENCE_RE.match(line_body)
+        leading_spaces = len(line_body) - len(line_body.lstrip(" "))
+        content_after_indent = line_body[leading_spaces:]
+        is_indented_code = leading_spaces >= 4 or content_after_indent.startswith("\t")
+
+        if active_fence is not None:
+            spans.append((offset, offset + len(line)))
+            if fence_match:
+                fence = fence_match.group("fence")
+                is_closing_fence = not line_body[fence_match.end() :].strip()
+                if (
+                    fence[0] == active_fence[0]
+                    and len(fence) >= active_fence[1]
+                    and is_closing_fence
+                ):
+                    active_fence = None
+        elif fence_match:
+            fence = fence_match.group("fence")
+            active_fence = (fence[0], len(fence))
+            spans.append((offset, offset + len(line)))
+        elif is_indented_code:
+            spans.append((offset, offset + len(line)))
+
+        offset += len(line)
+
+    spans.extend(
+        match.span()
+        for match in _REFERENCE_TOKEN_RE.finditer(text)
+        if _token_is_reference(match.group(0))
+    )
+    return _merge_spans(spans)
+
+
+def find_unprotected_word_spans(text: str, word: str) -> list[tuple[int, int]]:
+    """Find whole-word matches safe for legacy loose emotion matching."""
+
+    if not text or not word:
+        return []
+
+    protected_spans = _protected_reference_spans(text)
+    protected_index = 0
+    matches: list[tuple[int, int]] = []
+    pattern = re.compile(r"\b(" + re.escape(word) + r")\b")
+
+    for match in pattern.finditer(text):
+        start, end = match.span(1)
+        while (
+            protected_index < len(protected_spans)
+            and protected_spans[protected_index][1] <= start
+        ):
+            protected_index += 1
+        if protected_index < len(protected_spans):
+            protected_start, protected_end = protected_spans[protected_index]
+            if protected_start <= start and end <= protected_end:
+                continue
+        matches.append((start, end))
+
+    return matches

--- a/mixins/event_handlers.py
+++ b/mixins/event_handlers.py
@@ -36,6 +36,10 @@ from ..backend.semantic_query import (
     validate_selected_id,
 )
 from ..backend.semantic_storage import invalidate_semantic_metadata
+from ..backend.text_safety import (
+    find_unprotected_word_spans,
+    strip_internal_image_ref_lines,
+)
 from ..config import MEMES_DIR, PLUGIN_DATA_DIR
 
 
@@ -325,6 +329,12 @@ class EventHandlerMixin:
         if isinstance(message, str):
             return [Plain(message)]
         raise TypeError("message 必须是 str、list 或 MessageChain")
+
+    def _clean_outgoing_plain_text(self, text: str) -> str:
+        cleaned = strip_internal_image_ref_lines(text or "")
+        if self.content_cleanup_rule:
+            cleaned = re.sub(self.content_cleanup_rule, "", cleaned)
+        return cleaned
 
     def _extract_marked_emotions_from_text(
         self,
@@ -803,6 +813,11 @@ class EventHandlerMixin:
             return
 
         text = response.completion_text
+        cleaned_text = strip_internal_image_ref_lines(text)
+        if cleaned_text != text:
+            response.completion_text = cleaned_text
+            text = cleaned_text
+            logger.debug("[meme_manager] Removed internal image references from reply")
         # Semantic packs use one exclusive route: reply-model Tool calls or
         # emotion-assistant candidate selection. Neither uses legacy guessing.
         semantic_mode = (
@@ -979,27 +994,28 @@ class EventHandlerMixin:
         ):
             # 查找所有可能的表情词
             for emotion in valid_emoticons:
-                # 使用单词边界确保不是其他单词的一部分
-                pattern = r"\b(" + re.escape(emotion) + r")\b"
-                for match in re.finditer(pattern, clean_text):
-                    word = match.group(1)
-                    position = match.start()
+                scan_text = clean_text
+                accepted_spans = []
+                for start, end in find_unprotected_word_spans(scan_text, emotion):
+                    word = scan_text[start:end]
+                    position = start
 
                     # 跳过thinking标签内的内容
-                    if self._is_position_in_thinking_tags(clean_text, position):
+                    if self._is_position_in_thinking_tags(scan_text, position):
                         continue
 
                     # 判断是否可能是表情而非英文单词
                     if self._is_likely_emotion(
-                        word, clean_text, position, valid_emoticons
+                        word, scan_text, position, valid_emoticons
                     ):
                         # 添加到表情列表
                         found_emotions.append(word)
                         loose_emotions.append(word)
-                        # 替换文本中的表情词
-                        clean_text = (
-                            clean_text[:position] + clean_text[position + len(word) :]
-                        )
+                        accepted_spans.append((start, end))
+
+                # 逆序删除，避免同一词多次命中时索引漂移。
+                for start, end in reversed(accepted_spans):
+                    clean_text = clean_text[:start] + clean_text[end:]
 
         logger.debug(f"[meme_manager] 松散匹配阶段找到的表情: {loose_emotions}")
 
@@ -1127,12 +1143,6 @@ class EventHandlerMixin:
         if not result:
             return
 
-        # 流式传输兼容处理
-        if result.result_content_type == ResultContentType.STREAMING_FINISH:
-            if self.streaming_compatibility or event.get_platform_name() == "webchat":
-                await self._send_memes_streaming(event)
-            return
-
         try:
             # 第一步：获取并清理原始消息链中的文本
             original_chain = result.chain
@@ -1142,11 +1152,7 @@ class EventHandlerMixin:
                 # 处理不同类型的消息链
                 if isinstance(original_chain, str):
                     # 字符串类型：清理后转为 Plain 组件
-                    cleaned = (
-                        re.sub(self.content_cleanup_rule, "", original_chain)
-                        if self.content_cleanup_rule
-                        else original_chain
-                    )
+                    cleaned = self._clean_outgoing_plain_text(original_chain)
                     if cleaned.strip():
                         cleaned_components.append(Plain(cleaned.strip()))
 
@@ -1154,11 +1160,7 @@ class EventHandlerMixin:
                     # MessageChain 类型：遍历清理 Plain 组件
                     for component in original_chain.chain:
                         if isinstance(component, Plain):
-                            cleaned = (
-                                re.sub(self.content_cleanup_rule, "", component.text)
-                                if self.content_cleanup_rule
-                                else component.text
-                            )
+                            cleaned = self._clean_outgoing_plain_text(component.text)
                             if cleaned.strip():
                                 cleaned_components.append(Plain(cleaned.strip()))
                         else:
@@ -1169,15 +1171,19 @@ class EventHandlerMixin:
                     # 列表类型：遍历清理 Plain 组件
                     for component in original_chain:
                         if isinstance(component, Plain):
-                            cleaned = (
-                                re.sub(self.content_cleanup_rule, "", component.text)
-                                if self.content_cleanup_rule
-                                else component.text
-                            )
+                            cleaned = self._clean_outgoing_plain_text(component.text)
                             if cleaned.strip():
                                 cleaned_components.append(Plain(cleaned.strip()))
                         else:
                             cleaned_components.append(component)
+
+            # 流式结果同样需要最后一道 Plain 文本清理。
+            if result.result_content_type == ResultContentType.STREAMING_FINISH:
+                if isinstance(original_chain, (str, MessageChain, list)):
+                    result.chain = cleaned_components
+                if self.streaming_compatibility or event.get_platform_name() == "webchat":
+                    await self._send_memes_streaming(event)
+                return
 
             # 第二步：语义模式按候选 ID 精确取图，不走概率、分类目录和 random.choice。
             semantic_selected_ids = (
@@ -1290,30 +1296,9 @@ class EventHandlerMixin:
             event.set_extra("meme_manager_semantic_selected_ids", None)
 
             # 第三步：更新消息链
-            if cleaned_components:
-                # 直接使用组件列表，不要包装在 MessageChain 中
+            if isinstance(original_chain, (str, MessageChain, list)):
+                # 始终写回安全处理后的组件列表，空列表也不能回退到原始脏文本。
                 result.chain = cleaned_components
-            elif original_chain:
-                # 如果原本有内容但清理后为空，也要更新（避免发送带标签的空消息）
-                # 进行最后的防御性清理
-                if isinstance(original_chain, str):
-                    final_cleaned = re.sub(
-                        r"&&+", "", original_chain
-                    )  # 清除残留的&&符号
-                    if final_cleaned.strip():
-                        result.chain = [Plain(final_cleaned.strip())]
-                elif isinstance(original_chain, MessageChain):
-                    # 对 MessageChain 中的每个 Plain 组件进行最后清理
-                    final_components = []
-                    for component in original_chain.chain:
-                        if isinstance(component, Plain):
-                            final_cleaned = re.sub(r"&&+", "", component.text)
-                            if final_cleaned.strip():
-                                final_components.append(Plain(final_cleaned.strip()))
-                        else:
-                            final_components.append(component)
-                    if final_components:
-                        result.chain = final_components
 
             logger.debug("[meme_manager] on_decorating_result 处理完成")
 

--- a/tests/test_text_safety.py
+++ b/tests/test_text_safety.py
@@ -1,0 +1,234 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from backend.text_safety import (
+    find_unprotected_word_spans,
+    strip_internal_image_ref_lines,
+)
+
+
+class StripInternalImageRefLinesTests(unittest.TestCase):
+    def test_removes_original_observed_reference(self):
+        text = (
+            "导师，公开教程没有写这个开关。\n"
+            "[Image Ref 1] "
+            "file:///AstrBot/data/plugin_data/meme_manager/packs/"
+            "legacy-migrated/memes/confused/1739434694_1.jpg"
+        )
+
+        self.assertEqual(
+            strip_internal_image_ref_lines(text),
+            "导师，公开教程没有写这个开关。\n",
+        )
+
+    def test_removes_latest_bare_and_numbered_references(self):
+        text = (
+            "来啦来啦，导师发话莉莉哪敢怠慢喵！\n"
+            " file:///AstrBot/data/plugin_data/meme_manager/packs/"
+            "legacy-migrated/memes/shy/02B099.jpg\n"
+            "[Image Ref 1] file:///AstrBot/data/plugin_data/"
+            "meme_manager/packs/legacy-migrated/memes/1739434736_2.jpg\n"
+            "[Image Ref 2] file:///AstrBot/data/plugin_data/"
+            "meme_manager/packs/legacy-migrated/memes/1739434736_2.jpg"
+        )
+
+        self.assertEqual(
+            strip_internal_image_ref_lines(text),
+            "来啦来啦，导师发话莉莉哪敢怠慢喵！\n",
+        )
+
+    def test_preserves_crlf_while_removing_middle_reference(self):
+        text = (
+            "前文\r\n"
+            "[Image Ref 1] file:///AstrBot/data/memes/confused/a.jpg\r\n"
+            "后文\r\n"
+        )
+
+        self.assertEqual(
+            strip_internal_image_ref_lines(text),
+            "前文\r\n后文\r\n",
+        )
+
+    def test_removes_supported_marked_reference_forms(self):
+        references = (
+            "file:////AstrBot/data/a.png",
+            "FILE:/AstrBot/data/a.GIF",
+            "file://localhost/AstrBot/data/a.webp",
+            "file:///C:/AstrBot/data/a%20b.jpeg",
+            "file://C:/AstrBot/data/a.jpg",
+            "file://server/share/AstrBot/data/a.jpg",
+            "https://example.com/assets/a.png?size=large",
+            "/AstrBot/data/a.jpg",
+            r"C:\AstrBot\data\a.jpeg",
+            r"\\server\share\AstrBot\data\a.webp",
+            "data:image/png;base64,AA==",
+            "base64://AA==",
+        )
+
+        for index, reference in enumerate(references, start=1):
+            with self.subTest(reference=reference):
+                text = f"[Image Ref {index}] {reference}"
+                self.assertEqual(strip_internal_image_ref_lines(text), "")
+
+    def test_removes_multiple_reference_lines(self):
+        text = (
+            "[Image Ref 1] file:///AstrBot/data/a.jpg\n"
+            "保留正文\n"
+            "[Image Ref 2]: <https://example.com/b.webp>\n"
+        )
+
+        self.assertEqual(strip_internal_image_ref_lines(text), "保留正文\n")
+
+    def test_preserves_user_visible_or_malformed_text(self):
+        examples = (
+            "请打开 file:///AstrBot/data/confused/a.jpg",
+            "调试输出：[Image Ref 1] file:///AstrBot/data/a.jpg",
+            "> [Image Ref 1] file:///AstrBot/data/a.jpg",
+            "    [Image Ref 1] file:///AstrBot/data/a.jpg",
+            "\t[Image Ref 1] file:///AstrBot/data/a.jpg",
+            "    file:///AstrBot/data/a.jpg",
+            "\tfile:///AstrBot/data/a.jpg",
+            "file:///tmp/example.jpg",
+            "<file:///tmp/example.jpg>",
+            "![Image Ref 1](file:///AstrBot/data/a.jpg)",
+            "[Image Ref abc] file:///AstrBot/data/a.jpg",
+            "[Image Ref 0] file:///AstrBot/data/a.jpg",
+            "[Image Ref 1] file:///AstrBot/data/readme.txt",
+            "[Image Ref 1] file:relative/a.jpg",
+            "[Image Ref 1] file:///AstrBot/data/a.jpg 后面还有说明",
+            "[Image Ref 1] http://[invalid/a.jpg",
+            "file://[invalid/a.jpg",
+            "https://example.com/a.jpg",
+        )
+
+        for text in examples:
+            with self.subTest(text=text):
+                self.assertEqual(strip_internal_image_ref_lines(text), text)
+
+    def test_preserves_reference_example_inside_fenced_code(self):
+        text = (
+            "```text\n"
+            "[Image Ref 1] file:///AstrBot/data/a.jpg\n"
+            "file:///AstrBot/data/a.jpg\n"
+            "```\n"
+            "正文\n"
+        )
+
+        self.assertEqual(strip_internal_image_ref_lines(text), text)
+
+    def test_fence_with_info_is_not_treated_as_a_closing_fence(self):
+        text = (
+            "```text\n"
+            "```not-a-close\n"
+            "[Image Ref 1] file:///AstrBot/data/a.jpg\n"
+            "```\n"
+        )
+
+        self.assertEqual(strip_internal_image_ref_lines(text), text)
+
+    def test_import_has_no_astrbot_dependency(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        code = """
+import importlib.abc
+import sys
+
+class DenyAstrBot(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "astrbot" or fullname.startswith("astrbot."):
+            raise RuntimeError(f"unexpected AstrBot import: {fullname}")
+        return None
+
+sys.meta_path.insert(0, DenyAstrBot())
+from backend.text_safety import strip_internal_image_ref_lines
+assert strip_internal_image_ref_lines(
+    "[Image Ref 1] file:///AstrBot/data/a.jpg"
+) == ""
+"""
+        subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=repo_root,
+            check=True,
+        )
+
+
+class FindUnprotectedWordSpansTests(unittest.TestCase):
+    def test_skips_path_uri_markdown_domain_and_filename_tokens(self):
+        examples = (
+            "file:///AstrBot/data/memes/confused/a.jpg",
+            r"C:\AstrBot\data\confused\a.jpg",
+            "/AstrBot/data/memes/confused/a.jpg",
+            "https://example.com/memes/confused/a.jpg",
+            "![confused](https://example.com/a.jpg)",
+            "[meme](assets/confused/a.jpg)",
+            "`/tmp/confused/a.jpg`",
+            "confused.example.com",
+            "confused.jpg",
+        )
+
+        for text in examples:
+            with self.subTest(text=text):
+                self.assertEqual(find_unprotected_word_spans(text, "confused"), [])
+
+    def test_skips_fenced_and_indented_code(self):
+        examples = (
+            "```text\nconfused\n```\n",
+            "~~~\nconfused\n~~~\n",
+            "    confused\n",
+            "\tconfused\n",
+        )
+
+        for text in examples:
+            with self.subTest(text=text):
+                self.assertEqual(find_unprotected_word_spans(text, "confused"), [])
+
+    def test_keeps_natural_prose_available_for_loose_matching(self):
+        examples = (
+            "这次真的 confused！",
+            "选A/B，然后，confused",
+            "见https://example.com/a，然后，confused",
+        )
+
+        for text in examples:
+            with self.subTest(text=text):
+                start = text.index("confused")
+                self.assertEqual(
+                    find_unprotected_word_spans(text, "confused"),
+                    [(start, start + len("confused"))],
+                )
+
+    def test_returns_multiple_natural_matches_in_source_order(self):
+        text = "confused，然后还是 confused"
+        first = text.index("confused")
+        second = text.rindex("confused")
+
+        self.assertEqual(
+            find_unprotected_word_spans(text, "confused"),
+            [
+                (first, first + len("confused")),
+                (second, second + len("confused")),
+            ],
+        )
+
+    def test_keeps_path_match_protected_after_natural_match(self):
+        text = "confused file:///AstrBot/data/memes/confused/a.jpg"
+        first = text.index("confused")
+
+        self.assertEqual(
+            find_unprotected_word_spans(text, "confused"),
+            [(first, first + len("confused"))],
+        )
+
+    def test_handles_many_reference_tokens_without_exposing_matches(self):
+        paths = [
+            f"file:///AstrBot/data/memes/confused/{index}.jpg"
+            for index in range(500)
+        ]
+        text = " ".join(paths)
+
+        self.assertEqual(find_unprotected_word_spans(text, "confused"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove standalone internal `[Image Ref N]` lines and plugin-owned bare `file:` image URIs before delivery
- prevent legacy loose emotion matching inside URIs, paths, Markdown links, filenames, and code
- delete multiple loose matches in reverse order to avoid index drift
- apply the final plain-text cleanup to streaming results as well

## Tests

- `python -m unittest discover -s tests -p "test_*.py" -v` — 15 passed
- `python -m compileall -q backend mixins main.py`
- `git diff --check origin/main...HEAD`

## Notes

- full AstrBot end-to-end integration was not run locally; the focused unit tests cover the response-cleanup and loose-matching regressions.