### PR TITLE
fix(webui): 移动端适配修复——抽屉侧栏、横向溢出与弹窗滚动穿透

### DIFF
--- a/pages/a_manage/index.html
+++ b/pages/a_manage/index.html
@@ -159,6 +159,14 @@
             <p class="left-panel-eyebrow">控制台</p>
             <h2>管理控制台</h2>
           </div>
+          <button
+            type="button"
+            class="panel-close-btn"
+            data-panel-close="console"
+            aria-label="收起控制台"
+          >
+            <i class="fas fa-xmark"></i>
+          </button>
         </div>
 
         <div class="console-section-heading">
@@ -247,7 +255,17 @@
 
       <aside class="directory-panel" id="app-directory-panel">
         <div id="sidebar">
-          <h2><i class="fas fa-folder-open icon"></i>目录</h2>
+          <div class="directory-panel-header">
+            <h2><i class="fas fa-folder-open icon"></i>目录</h2>
+            <button
+              type="button"
+              class="panel-close-btn"
+              data-panel-close="directory"
+              aria-label="收起目录"
+            >
+              <i class="fas fa-xmark"></i>
+            </button>
+          </div>
           <ul id="sidebar-list"></ul>
         </div>
       </aside>

--- a/pages/a_manage/script.js
+++ b/pages/a_manage/script.js
@@ -2582,12 +2582,22 @@ async function initApp() {
   }
 
   function toggleConsolePanel() {
-    setConsoleVisible(!isConsoleVisible());
+    const visible = !isConsoleVisible();
+    if (visible && isCompactViewport()) {
+      // 移动端抽屉互斥：打开控制台时先收起目录
+      setDirectoryVisible(false);
+    }
+    setConsoleVisible(visible);
     updatePanelToggleState();
   }
 
   function toggleDirectoryPanel() {
-    setDirectoryVisible(!isDirectoryVisible());
+    const visible = !isDirectoryVisible();
+    if (visible && isCompactViewport()) {
+      // 移动端抽屉互斥：打开目录时先收起控制台
+      setConsoleVisible(false);
+    }
+    setDirectoryVisible(visible);
     updatePanelToggleState();
   }
 
@@ -5232,6 +5242,26 @@ async function initApp() {
 
   if (sidebarBackdrop) {
     sidebarBackdrop.addEventListener("click", () => {
+      closeAllPanels();
+      updatePanelToggleState();
+    });
+  }
+
+  document.querySelectorAll(".panel-close-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      closeAllPanels();
+      updatePanelToggleState();
+    });
+  });
+
+  const sidebarListElement = document.getElementById("sidebar-list");
+  if (sidebarListElement) {
+    sidebarListElement.addEventListener("click", (event) => {
+      const link = event.target.closest("a");
+      if (!link || !isCompactViewport()) {
+        return;
+      }
+      // 移动端：选中目录项后自动收起抽屉，让正文露出来
       closeAllPanels();
       updatePanelToggleState();
     });

--- a/pages/a_manage/script.js
+++ b/pages/a_manage/script.js
@@ -2271,6 +2271,7 @@ async function initApp() {
     }
     renderImageSemantic(null, { loading: true });
     setImagePreviewBusy(false);
+    unlockPageScroll();
   }
 
   async function openImagePreview(category, emoji, previewDataUrl = "") {
@@ -2285,6 +2286,7 @@ async function initApp() {
       semantic: null,
     };
     imagePreviewState = previewState;
+    lockPageScroll();
     imagePreviewModalRoot.classList.remove("hidden");
     imagePreviewModalRoot.setAttribute("aria-hidden", "false");
     imagePreviewImg.alt = `表情包预览：${emoji}`;
@@ -2397,6 +2399,7 @@ async function initApp() {
       confirmResolver = null;
       resolver(result);
     }
+    unlockPageScroll();
   }
 
   function showConfirm({
@@ -2421,6 +2424,7 @@ async function initApp() {
       "danger",
       confirmClassName.includes("danger"),
     );
+    lockPageScroll();
     confirmModalRoot.classList.remove("hidden");
     confirmModalRoot.setAttribute("aria-hidden", "false");
 
@@ -2483,6 +2487,33 @@ async function initApp() {
 
   function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  // 模态弹窗共享滚动锁：计数式，支持弹窗叠加（预览上再弹确认框）
+  let scrollLockCount = 0;
+  let scrollLockSavedY = 0;
+
+  function lockPageScroll() {
+    scrollLockCount += 1;
+    if (scrollLockCount > 1) {
+      return;
+    }
+    scrollLockSavedY = window.scrollY || 0;
+    document.body.classList.add("page-scroll-locked");
+    document.body.style.top = `-${scrollLockSavedY}px`;
+  }
+
+  function unlockPageScroll() {
+    if (scrollLockCount === 0) {
+      return;
+    }
+    scrollLockCount -= 1;
+    if (scrollLockCount > 0) {
+      return;
+    }
+    document.body.classList.remove("page-scroll-locked");
+    document.body.style.top = "";
+    window.scrollTo(0, scrollLockSavedY);
   }
 
   function isCompactViewport() {
@@ -3876,6 +3907,7 @@ async function initApp() {
     if (moveTargetList) {
       moveTargetList.innerHTML = "";
     }
+    unlockPageScroll();
   }
 
   function openMoveTargetModal(
@@ -3931,6 +3963,7 @@ async function initApp() {
     }
 
     if (moveTargetModalRoot) {
+      lockPageScroll();
       moveTargetModalRoot.classList.remove("hidden");
       moveTargetModalRoot.setAttribute("aria-hidden", "false");
     }
@@ -4847,6 +4880,7 @@ async function initApp() {
       dangerConfirmResolver = null;
       resolver(result);
     }
+    unlockPageScroll();
   }
 
   function startDangerCountdown() {
@@ -4915,6 +4949,7 @@ async function initApp() {
       dangerModalConfirmBtn.textContent = "请先勾选上方选项";
       dangerModalConfirmBtn.disabled = true;
     }
+    lockPageScroll();
     dangerModalRoot.classList.remove("hidden");
     dangerModalRoot.setAttribute("aria-hidden", "false");
 
@@ -5918,6 +5953,7 @@ async function initApp() {
     if (categoryEditDescInput) {
       categoryEditDescInput.value = "";
     }
+    unlockPageScroll();
   }
 
   // 编辑类别
@@ -5944,6 +5980,7 @@ async function initApp() {
           : "";
     }
     if (categoryEditModalRoot) {
+      lockPageScroll();
       categoryEditModalRoot.classList.remove("hidden");
       categoryEditModalRoot.setAttribute("aria-hidden", "false");
     }

--- a/pages/a_manage/style.css
+++ b/pages/a_manage/style.css
@@ -2091,6 +2091,23 @@ body.app-page {
   color: #0f766e;
 }
 
+.directory-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+#sidebar .directory-panel-header h2 {
+  margin-bottom: 0;
+}
+
+/* 抽屉关闭按钮：桌面端隐藏，仅在移动端抽屉模式下显示 */
+.panel-close-btn {
+  display: none;
+}
+
 body.panel-console-hidden .container {
   grid-template-columns: 0 minmax(180px, var(--directory-width)) minmax(0, 1fr);
 }
@@ -2452,6 +2469,15 @@ body.drag-session-active {
   overscroll-behavior: none;
 }
 
+@keyframes sidebar-backdrop-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 @media (max-width: 960px) {
   body.app-page {
     padding: 12px;
@@ -2469,24 +2495,32 @@ body.drag-session-active {
     grid-template-columns: 1fr;
   }
 
-  .left-panel {
+  /* 移动端抽屉：两个面板统一为左侧全高浮层，自身滚动，不再挤压正文 */
+  .left-panel,
+  .directory-panel {
     position: fixed;
-    inset: 12px auto auto 12px;
+    top: 0;
+    bottom: 0;
+    left: 0;
     z-index: 9997;
-    width: min(88vw, 340px);
-    max-height: calc(58svh - 18px);
-    transform: translateX(calc(-100% - 24px));
-    transition: transform 0.22s ease;
+    width: min(86vw, 340px);
+    max-height: none;
+    border-radius: 0 24px 24px 0;
+    padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+    transform: translateX(calc(-100% - 32px));
+    visibility: hidden;
+    transition:
+      transform 0.26s cubic-bezier(0.32, 0.72, 0, 1),
+      visibility 0s linear 0.26s;
+  }
+
+  .left-panel {
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
 
   .directory-panel {
-    position: fixed;
-    inset: auto auto 12px 12px;
-    z-index: 9997;
-    width: min(88vw, 340px);
-    max-height: calc(42svh - 18px);
-    transform: translateX(calc(-100% - 24px));
-    transition: transform 0.22s ease;
+    overflow: hidden;
   }
 
   body.panel-console-open,
@@ -2498,6 +2532,53 @@ body.drag-session-active {
   body.panel-directory-open .directory-panel {
     transform: translateX(0);
     opacity: 1;
+    visibility: visible;
+    box-shadow: 24px 0 60px rgba(15, 23, 42, 0.16);
+    transition:
+      transform 0.26s cubic-bezier(0.32, 0.72, 0, 1),
+      box-shadow 0.26s ease;
+  }
+
+  .panel-close-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 44px;
+    width: 44px;
+    height: 44px;
+    margin-left: auto;
+    padding: 0;
+    gap: 0;
+    border: 1px solid rgba(214, 229, 225, 0.94);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.92);
+    color: var(--ui-muted);
+    font-size: 15px;
+    cursor: pointer;
+    transition:
+      background 0.18s ease,
+      color 0.18s ease,
+      transform 0.12s ease;
+  }
+
+  .panel-close-btn i {
+    margin: 0;
+  }
+
+  .panel-close-btn:hover {
+    background: var(--ui-brand-soft, #e7f5ef);
+    color: var(--ui-brand-strong, #176d51);
+    filter: none;
+    transform: none;
+    box-shadow: none;
+  }
+
+  .panel-close-btn:active {
+    transform: scale(0.92);
+  }
+
+  .sidebar-backdrop:not(.hidden) {
+    animation: sidebar-backdrop-fade 0.22s ease;
   }
 
   #content {
@@ -2957,7 +3038,7 @@ button.danger,
   color: #1f2937;
 }
 
-/* Mobile sidebar behavior: keep control panel right below the sidebar trigger */
+/* 移动端页头与操作区排版（面板抽屉规则见上方 960px 断点块） */
 @media (max-width: 960px) {
   .page-header {
     display: block;
@@ -2981,40 +3062,8 @@ button.danger,
     gap: 12px;
   }
 
-  .left-panel,
-  .directory-panel {
-    position: static;
-    inset: auto;
-    width: 100%;
-    max-height: none;
-    transform: none;
-    transition: none;
-    box-shadow: var(--ui-shadow-sm);
-  }
-
-  .left-panel {
-    display: none;
-    margin-top: 0;
-  }
-
-  .directory-panel {
-    display: none;
-  }
-
   .category-actions {
     flex-wrap: wrap;
-  }
-
-  body.panel-console-open .left-panel {
-    display: flex;
-  }
-
-  body.panel-directory-open .directory-panel {
-    display: flex;
-  }
-
-  .sidebar-backdrop {
-    display: none;
   }
 }
 
@@ -4289,5 +4338,21 @@ button.compact {
   .left-panel .pack-transfer-panel {
     width: 100%;
     padding: 12px;
+  }
+}
+
+/* 减弱动效偏好：关闭抽屉滑动与遮罩淡入（置于文件末尾以保证级联胜出） */
+@media (prefers-reduced-motion: reduce) {
+  .left-panel,
+  .directory-panel,
+  .sidebar-backdrop,
+  body.panel-console-open .left-panel,
+  body.panel-directory-open .directory-panel {
+    transition: none;
+    animation: none;
+  }
+
+  .sidebar-backdrop:not(.hidden) {
+    animation: none;
   }
 }

--- a/pages/a_manage/style.css
+++ b/pages/a_manage/style.css
@@ -3662,7 +3662,7 @@ body.page-scroll-locked {
     width: min(94vw, 680px);
     height: min(92svh, 900px);
     display: grid;
-    grid-template-rows: minmax(240px, 1fr) auto;
+    grid-template-rows: minmax(240px, auto) auto;
     align-items: stretch;
     overflow-y: auto;
   }
@@ -3670,6 +3670,7 @@ body.page-scroll-locked {
   .image-preview-frame {
     min-width: 0;
     min-height: 240px;
+    max-height: none;
   }
 
   .image-preview-frame img {

--- a/pages/a_manage/style.css
+++ b/pages/a_manage/style.css
@@ -1545,6 +1545,7 @@ button:disabled {
   background: rgba(15, 23, 42, 0.45);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
+  overscroll-behavior: contain;
 }
 
 .image-preview-modal {
@@ -3225,12 +3226,22 @@ button.danger,
   max-height: 86svh;
 }
 
+/* 模态弹窗期间锁定页面滚动，防止背景滚动穿透（iOS 需 fixed body 方案） */
+body.page-scroll-locked {
+  position: fixed;
+  left: 0;
+  right: 0;
+  width: 100%;
+  overflow: hidden;
+}
+
 .image-preview-semantic {
   flex: 0 0 min(420px, 38vw);
   width: min(420px, 38vw);
   max-height: 88svh;
   padding: 20px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.97);

--- a/pages/catalog/style.css
+++ b/pages/catalog/style.css
@@ -599,32 +599,13 @@ button:disabled {
 
 .log-item.error {
   border-left-color: var(--danger);
-  background: #fff3f1;
-}
-
-@media (max-width: 960px) {
-  .format-guide {
-    grid-template-columns: 1fr;
-  }
-
-  .triple-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .page-header {
-    flex-direction: column;
-  }
-}
-
-.log-item.error {
-  border-left-color: var(--danger);
   background: #fff5f4;
 }
 
+/* 移动端布局：合并原 960/980 两个重复断点块，清除重复规则 */
 @media (max-width: 980px) {
-  .manual-source,
-  .catalog-list {
-    grid-column: span 12;
+  .format-guide {
+    grid-template-columns: 1fr;
   }
 
   .triple-grid {

--- a/pages/semantic/style.css
+++ b/pages/semantic/style.css
@@ -531,6 +531,10 @@ button:disabled {
   .concurrency-field {
     width: 100%;
   }
+}
+
+/* record 四列展开约需 814px 视口，提前折叠避免 iPad 竖屏（768px）横向溢出 */
+@media (max-width: 820px) {
   .record {
     grid-template-columns: 1fr;
     gap: 8px;

--- a/pages/semantic/style.css
+++ b/pages/semantic/style.css
@@ -301,12 +301,14 @@ button:disabled {
 }
 .metric-group-content {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  /* auto-fit 轨道数跟随容器宽度，被长内容撑宽后溢出会自我维持，改 auto-fill 并封死轨道宽度 */
+  grid-template-columns: repeat(auto-fill, minmax(min(150px, 100%), 1fr));
   gap: 10px;
   padding: 0 10px 10px;
 }
 .metric {
   min-height: 78px;
+  min-width: 0;
   padding: 13px;
   border: 1px solid var(--line);
   border-radius: 12px;
@@ -317,6 +319,7 @@ button:disabled {
   margin-bottom: 7px;
   color: var(--muted);
   font-size: 12px;
+  overflow-wrap: anywhere;
 }
 .metric strong {
   display: block;
@@ -365,6 +368,7 @@ button:disabled {
   background: #ede9fe;
   color: #5b21b6;
   font-weight: 700;
+  overflow-wrap: anywhere;
 }
 .record-preview-button {
   width: 92px;
@@ -517,6 +521,12 @@ button:disabled {
   }
   .layout {
     padding: 8px 14px 24px;
+  }
+  /* 兑底：任务状态/记录面板内任何超宽内容只允许面板内横向滚动，不撑出页面滚动条 */
+  .status-panel,
+  .records-panel {
+    max-width: 100%;
+    overflow-x: auto;
   }
   .panel-header {
     flex-direction: column;

--- a/pages/settings/style.css
+++ b/pages/settings/style.css
@@ -547,6 +547,15 @@ button:disabled {
   margin-top: 2px;
 }
 
+/* 防止长文件名在窄屏撑破网格/弹性布局的中间列 */
+.pack-transfer-section summary span,
+.export-mode-option span,
+.pack-import-dropzone span,
+.pack-import-preview-header div {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .pack-import-preview-stats {
   margin: 0;
   display: grid;


### PR DESCRIPTION
   ## 问题与修复

   ### 1. 管理页侧面板内联展开挤压正文

   移动端点击"控制台/目录"时，面板以 `position: static` 满宽块插入页面流，把正文整体推开 ；控制台面板内容超过一屏半，且无遮罩、无法点外部关闭。

   根因是 CSS 层叠冲突：文件内有一套完整的 drawer 实现（`position: fixed` + 滑入动画）， 但被后方一个同断点块覆盖回内联展开模式；JS 侧（backdrop 点击、Esc、aria 同步、滚动锁定）本就按 drawer 编写，CSS/JS 长期不同步。

   修复：
   - 删除覆盖块中的面板/backdrop 规则，两面板统一为左侧全高浮层抽屉（`min(86vw, 340px)`，≤560px近全宽），自身滚动，正文不再位移
   - 面板头部新增 44×44pt 关闭按钮；目录项点击后自动收起；移动端两抽屉互斥
   - backdrop 淡入、`env(safe-area-inset-bottom)` 适配、`prefers-reduced-motion` 下关闭全部动效

   ### 2. 语义化页移动端横向溢出

   两处独立成因：

   - **记录列表**：`.record` 四列最小内容宽约 814px（含 gap 与面板 padding），但折叠断点在 720px——721–811px 视口（含 768px iPad 竖屏）必现横向滚动。断点提至 820px。
   - **任务状态指标网格**：`repeat(auto-fit, minmax(150px, 1fr))` 的轨道数随容器宽度计算，JS 动态填入的长内容（URL、错误详情）撑宽容器后，轨道数"自我证明"合理，形成自维持溢出。改为 `repeat(auto-fill, minmax(min(150px, 100%), 1fr))` 封顶轨道宽度；动态文本加 `overflow-wrap: anywhere`；状态/记录面板加 `max-width: 100% + overflow-x: auto` 作面板内滚动兜底。

   ### 3. 设置页长文件名撑破布局

   迁移摘要、导出选项、导入拖放区、导入预览头四处 `auto 1fr auto` / flex 布局的中间列缺 `min-width: 0`，长文件名（如导出的 zip 名）在窄屏撑出横向溢出。统一补齐 `min-width: 0 + overflow-wrap: anywhere`。

   ### 4. 资源广场重复断点块

   文件尾部存在 960px 与 980px 两个大面积重复的媒体查询块，`.log-item.error` 定义了两遍（后者级联胜出，前者死代码）。合并为单一 980px 块，保留生效值。

   ### 5. 弹窗滚动穿透

   五个模态弹窗（图片预览、确认、危险确认、移动目标、类别编辑）开关只切 `hidden` 类，从不锁页面滚动：遮罩/图片上滑动直接滚动背景页，预览右侧语义侧栏滚到边缘后滚动链也交给背景页。

   修复：
   - 新增计数式 `lockPageScroll()` / `unlockPageScroll()`（fixed body 方案，兼容旧版 iOS），五个弹窗开关全部接入，支持弹窗叠加（内层关闭不提前解锁），关闭后精确恢复滚动位置
   - `.image-preview-semantic` 与弹窗遮罩加 `overscroll-behavior: contain` 阻断滚动链