### PR TITLE
feat(meme): 表情附加触发范围与概率逻辑重构——来源门控、p² 去叠加与语义选图恒附加

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -201,6 +201,20 @@
     "description": "表情生成与发送",
     "type": "object",
     "items": {
+      "trigger": {
+        "description": "触发范围",
+        "type": "object",
+        "hint": "控制表情附加作用于哪些机器人发言",
+        "items": {
+          "scope": {
+            "description": "表情附加触发范围",
+            "type": "string",
+            "default": "only_chat_llm",
+            "options": ["only_chat_llm", "chat_and_plugin_llm"],
+            "hint": "only_chat_llm=仅对普通聊天 LLM 回复附加（默认）；chat_and_plugin_llm=同时对插件通过 event.request_llm 触发的 LLM 回复附加。第三方 Agent、指令和固定文本不触发"
+          }
+        }
+      },
       "emotion": {
         "description": "情感辅助与旧版分类回退",
         "type": "object",

--- a/main.py
+++ b/main.py
@@ -30,9 +30,9 @@ from .config import (
 from .image_host.img_sync import ImageSync
 from .init import init_plugin
 from .mixins.commands import CommandMixin
-from .mixins.event_handlers import EventHandlerMixin
+from .mixins.event_handlers import EventHandlerMixin, normalize_trigger_scope
 from .mixins.web_api import WebAPIMixin
-from .utils import dict_to_string, load_json, normalize_probability, probability_hit
+from .utils import dict_to_string, load_json
 
 MEME_PROMPT_MARKER_START = "<!-- meme_manager_prompt:start -->"
 MEME_PROMPT_MARKER_END = "<!-- meme_manager_prompt:end -->"
@@ -259,6 +259,13 @@ class MemeSender(Star, WebAPIMixin, CommandMixin, EventHandlerMixin):
             default="&&[a-zA-Z]*&&",
             legacy_keys=("content_cleanup_rule",),
         )
+        # 表情附加触发范围：仅普通聊天 / 普通聊天及插件触发的 LLM
+        self.trigger_scope = normalize_trigger_scope(
+            self._read_config_value(
+                ("generation", "trigger", "scope"),
+                default="only_chat_llm",
+            )
+        )
 
         # 构建表情包提示词
         self.sys_prompt_add = ""
@@ -308,6 +315,10 @@ class MemeSender(Star, WebAPIMixin, CommandMixin, EventHandlerMixin):
     async def handle_upload_image(self, event: AstrMessageEvent):
         async for result in self._handle_upload_image_impl(event):
             yield result
+
+    @filter.on_waiting_llm_request(priority=99999)
+    async def mark_llm_request_origin(self, event: AstrMessageEvent):
+        return await self._mark_llm_request_origin_impl(event)
 
     @filter.on_llm_request(priority=99999)
     async def inject_meme_prompt(self, event: AstrMessageEvent, req: ProviderRequest):
@@ -810,7 +821,6 @@ class MemeSender(Star, WebAPIMixin, CommandMixin, EventHandlerMixin):
     ) -> None:
         semantic_mode = ""
         semantic_tool_ready = False
-        semantic_probability_hit = None
         if self.emotion_llm_enabled:
             if self._semantic_pack_ready(event=event, req=req):
                 semantic_mode = "llm"
@@ -819,22 +829,11 @@ class MemeSender(Star, WebAPIMixin, CommandMixin, EventHandlerMixin):
                 event=event, req=req, require_tool=True
             )
             if semantic_tool_ready:
-                semantic_probability_hit = probability_hit(self.emotions_probability)
-                if semantic_probability_hit:
-                    semantic_mode = "tool"
-                logger.info(
-                    "[meme_manager] 语义表情触发判定: 概率=%s%%, 结果=%s",
-                    normalize_probability(self.emotions_probability),
-                    "命中" if semantic_probability_hit else "跳过",
-                )
+                semantic_mode = "tool"
         semantic_active = bool(semantic_mode)
         if event is not None and hasattr(event, "set_extra"):
             event.set_extra("meme_manager_semantic_active", semantic_active)
             event.set_extra("meme_manager_semantic_mode", semantic_mode)
-            event.set_extra(
-                "meme_manager_semantic_probability_hit",
-                semantic_probability_hit,
-            )
             event.set_extra(
                 "meme_manager_semantic_verified_pack_id",
                 str(event.get_extra("meme_manager_runtime_pack_id") or "")
@@ -855,11 +854,6 @@ class MemeSender(Star, WebAPIMixin, CommandMixin, EventHandlerMixin):
             )
             return
         self._remove_semantic_tool(req)
-        if semantic_tool_ready:
-            # 本轮概率未命中：既不暴露工具，也不回退到旧版标签提示，
-            # 避免绕过本轮概率判定后仍然产生表情。
-            req.system_prompt = self._strip_meme_prompt(req.system_prompt)
-            return
         if semantic_mode == "llm" or self.emotion_llm_enabled:
             req.system_prompt = self._strip_meme_prompt(req.system_prompt)
             return

--- a/mixins/event_handlers.py
+++ b/mixins/event_handlers.py
@@ -37,10 +37,67 @@ from ..backend.semantic_query import (
 )
 from ..backend.semantic_storage import invalidate_semantic_metadata
 from ..config import MEMES_DIR, PLUGIN_DATA_DIR
+from ..utils import probability_hit
+
+
+TRIGGER_SCOPE_CHAT_ONLY = "only_chat_llm"
+TRIGGER_SCOPE_CHAT_AND_PLUGIN = "chat_and_plugin_llm"
+LLM_REQUEST_ORIGIN_EXTRA_KEY = "meme_manager_llm_request_origin"
+LLM_REQUEST_ORIGIN_CHAT = "chat"
+LLM_REQUEST_ORIGIN_PLUGIN = "plugin"
+
+
+def normalize_trigger_scope(value: Any) -> str:
+    """将当前及旧版触发范围归一化为两档 LLM 来源范围。"""
+    scope = str(value or TRIGGER_SCOPE_CHAT_ONLY).strip().lower()
+    if scope in {"all_llm", "all_messages"}:
+        return TRIGGER_SCOPE_CHAT_AND_PLUGIN
+    if scope == TRIGGER_SCOPE_CHAT_AND_PLUGIN:
+        return scope
+    return TRIGGER_SCOPE_CHAT_ONLY
 
 
 class EventHandlerMixin:
     """处理图片上传、LLM 响应解析、消息装饰等事件"""
+
+    async def _mark_llm_request_origin_impl(self, event: AstrMessageEvent) -> None:
+        """在 AstrBot 构建默认请求前记录本轮 LLM 请求来源。"""
+        origin = (
+            LLM_REQUEST_ORIGIN_PLUGIN
+            if event.get_extra("provider_request") is not None
+            else LLM_REQUEST_ORIGIN_CHAT
+        )
+        event.set_extra(LLM_REQUEST_ORIGIN_EXTRA_KEY, origin)
+
+    def _scope_allows_llm_origin(self, event: AstrMessageEvent) -> bool:
+        """判断当前配置是否允许处理该来源的 LLM 请求。"""
+        scope = normalize_trigger_scope(getattr(self, "trigger_scope", None))
+        origin = event.get_extra(LLM_REQUEST_ORIGIN_EXTRA_KEY)
+        if origin == LLM_REQUEST_ORIGIN_CHAT:
+            return True
+        return (
+            scope == TRIGGER_SCOPE_CHAT_AND_PLUGIN
+            and origin == LLM_REQUEST_ORIGIN_PLUGIN
+        )
+
+    def _should_attach_for_result(
+        self,
+        event: AstrMessageEvent,
+        result: Any,
+    ) -> bool:
+        """仅允许配置范围内的内部聊天或插件 LLM 结果附加表情。"""
+        if result is None:
+            return False
+        if not self._scope_allows_llm_origin(event):
+            return False
+        content_type = getattr(result, "result_content_type", None)
+        content_type_name = str(getattr(content_type, "name", content_type) or "")
+        if content_type_name == "STREAMING_FINISH":
+            return True
+        checker = getattr(result, "is_llm_result", None)
+        if callable(checker):
+            return bool(checker())
+        return content_type_name == "LLM_RESULT"
 
     @staticmethod
     def _stringify_emotion_context_text(value: Any) -> str:
@@ -193,7 +250,9 @@ class EventHandlerMixin:
         if hasattr(event, "get_extra"):
             cached_lines = event.get_extra("meme_manager_emotion_context_lines")
             if isinstance(cached_lines, list):
-                lines = [str(item).strip() for item in cached_lines if str(item).strip()]
+                lines = [
+                    str(item).strip() for item in cached_lines if str(item).strip()
+                ]
 
         if lines:
             turns = int(getattr(self, "emotion_llm_context_turns", 0) or 0)
@@ -510,6 +569,12 @@ class EventHandlerMixin:
     async def _inject_meme_prompt_impl(
         self, event: AstrMessageEvent, req: ProviderRequest
     ) -> None:
+        if not self._scope_allows_llm_origin(event):
+            self._remove_semantic_tool(req)
+            req.system_prompt = self._strip_meme_prompt(req.system_prompt)
+            event.set_extra("meme_manager_semantic_active", False)
+            event.set_extra("meme_manager_semantic_mode", "")
+            return
         self._apply_request_prompt(req, event)
         if (
             self.emotion_llm_enabled
@@ -695,6 +760,8 @@ class EventHandlerMixin:
     async def _resp_impl(self, event: AstrMessageEvent, response: LLMResponse):
         """处理 LLM 响应，识别表情"""
 
+        if not self._scope_allows_llm_origin(event):
+            return
         if not response or not response.completion_text:
             return
 
@@ -899,7 +966,11 @@ class EventHandlerMixin:
 
         logger.debug(f"[meme_manager] 松散匹配阶段找到的表情: {loose_emotions}")
 
-        if self.emotion_llm_enabled:
+        # 概率预检：旧版路径只掷一次骰，结果存入 extra 供发送阶段复用，
+        # 避免“调用情感模型”与“发送表情”各自掷骰导致概率叠加（p²）。
+        legacy_probability_hit = probability_hit(self.emotions_probability)
+        event.set_extra("meme_manager_legacy_probability_hit", legacy_probability_hit)
+        if self.emotion_llm_enabled and legacy_probability_hit:
             try:
                 provider_id = await self._resolve_emotion_llm_provider_id(event)
                 if provider_id:
@@ -1086,10 +1157,17 @@ class EventHandlerMixin:
                             cleaned_components.append(component)
 
             # 第二步：语义模式按候选 ID 精确取图，不走概率、分类目录和 random.choice。
+            # 触发范围门控：仅在配置允许的消息类型上附加表情图片；
+            # 文本标记清理（第一步）不受此门控影响，始终执行。
+            scope_allows_attach = self._should_attach_for_result(event, result)
             semantic_selected_ids = (
                 event.get_extra("meme_manager_semantic_selected_ids") or []
             )
-            if semantic_selected_ids and self._semantic_mode_active(event):
+            if (
+                scope_allows_attach
+                and semantic_selected_ids
+                and self._semantic_mode_active(event)
+            ):
                 memes_root = self._get_runtime_memes_dir_for_event(event)
                 pack_context = self._resolve_runtime_pack_context(event=event)
                 semantic_images = []
@@ -1110,17 +1188,40 @@ class EventHandlerMixin:
                 if semantic_temp_files:
                     event.set_extra("meme_manager_temp_files", semantic_temp_files)
                 if semantic_images:
-                    # 语义模式不再随机丢弃模型已经选择的候选。
-                    event.set_extra("meme_manager_pending_images", semantic_images)
+                    # 语义模式不再随机丢弃模型已经选择的候选；
+                    # 发送方式（合并/分离）按 mixed_message 概率决定，与旧版路径一致。
+                    use_mixed_message = False
+                    if self.enable_mixed_message:
+                        use_mixed_message = (
+                            random.randint(1, 100) <= self.mixed_message_probability
+                        )
+                    if use_mixed_message and self.send_image_as_base64:
+                        normalized_images = []
+                        for image in semantic_images:
+                            normalized_images.append(
+                                await self._ensure_image_send_format(image)
+                            )
+                        semantic_images = normalized_images
+                    if use_mixed_message:
+                        cleaned_components = self._merge_components_with_images(
+                            cleaned_components, semantic_images
+                        )
+                    else:
+                        event.set_extra(
+                            "meme_manager_pending_images", semantic_images
+                        )
             # 第三步：旧模式添加表情图片（如果有找到的表情）
             found_emotions = event.get_extra("found_emotions") or []
-            if found_emotions and not semantic_selected_ids:
+            if scope_allows_attach and found_emotions and not semantic_selected_ids:
                 memes_root = self._get_runtime_memes_dir_for_event(event)
-                # 检查概率（注意：概率判断是"小于等于"才发送）
-                random_value = random.randint(1, 100)
-                threshold = self.emotions_probability
-
-                if random_value <= threshold:
+                # 概率判定复用 _resp_impl 阶段的预检结果（避免二次掷骰）；
+                # extra 缺失（异常路径）时回退本地掷骰，保持旧行为。
+                legacy_probability_hit = event.get_extra(
+                    "meme_manager_legacy_probability_hit"
+                )
+                if legacy_probability_hit is None:
+                    legacy_probability_hit = probability_hit(self.emotions_probability)
+                if legacy_probability_hit:
                     # 创建表情图片列表
                     emotion_images = []
                     temp_files = []  # 记录临时文件路径
@@ -1394,6 +1495,11 @@ class EventHandlerMixin:
 
     async def _send_memes_streaming(self, event: AstrMessageEvent):
         """流式传输兼容模式：在流式消息发送完成后，主动发送表情图片作为独立消息。"""
+        # 流式结果仍须通过请求来源门控，与非流式主路径保持一致。
+        if not self._should_attach_for_result(event, event.get_result()):
+            event.set_extra("meme_manager_semantic_selected_ids", None)
+            event.set_extra("found_emotions", None)
+            return
         semantic_selected_ids = (
             event.get_extra("meme_manager_semantic_selected_ids") or []
         )
@@ -1426,8 +1532,13 @@ class EventHandlerMixin:
         memes_root = self._get_runtime_memes_dir_for_event(event)
 
         try:
-            random_value = random.randint(1, 100)
-            if random_value > self.emotions_probability:
+            # 概率判定复用 _resp_impl 阶段的预检结果；extra 缺失时回退本地掷骰。
+            legacy_probability_hit = event.get_extra(
+                "meme_manager_legacy_probability_hit"
+            )
+            if legacy_probability_hit is None:
+                legacy_probability_hit = probability_hit(self.emotions_probability)
+            if not legacy_probability_hit:
                 return
 
             for emotion in found_emotions:


### PR DESCRIPTION
## 问题与修复

### 1. 表情附加无来源门控：插件触发的 LLM 回复也会附加表情

此前表情附加只判断"是否为 LLM 结果"，不区分这条回复是普通聊天还是插件触发。插件 Handler 通过返回 `ProviderRequest`（或 `event.request_llm`）走主 Agent 管线时，其 LLM 回复同样会被注入表情提示词、语义选图工具并附加表情——对工具型/功能型插件回复往往是噪声，且无法配置关闭。

根因是缺少请求来源的识别与门控：插件经主管线触发的 LLM 与普通聊天 LLM 走同一套处理，无从区分。

（注：插件用 `context.llm_generate()` 直调 `prov.text_chat` 的路径不经过主 Agent 钩子，本就不触发，不在本次范围内。）

修复：
- 新增配置 `generation.trigger.scope`，两档：`only_chat_llm`（默认，仅普通聊天 LLM 回复）/ `chat_and_plugin_llm`（同时对插件触发的 LLM 回复附加）
- 新增 `on_waiting_llm_request` 钩子（priority=99999，在 AstrBot 构建请求前触发、早于 `on_llm_request`），按事件 extra `provider_request` 是否存在判定本轮来源——该 extra 由管线在插件 Handler 产出 `ProviderRequest` 时写入——结果记入 `meme_manager_llm_request_origin`
- 门控贯穿全链路：提示词注入阶段（不允许时剥离表情提示词并移除语义选图工具，避免插件 LLM 输出标记）、响应解析 `_resp_impl`（提前返回）、发送装饰阶段（语义/旧版两条取图路径均门控）、流式路径 `_send_memes_streaming`
- 文本标记清理不受门控影响，始终执行，避免标记泄漏到最终回复

### 2. 概率逻辑：旧版双重掷骰（p²）与语义路径误门控

两处独立成因：

- **旧版路径 p²**：若在"调用情感模型"与"发送表情"两处各掷一次骰，两次独立 → 实际命中率是配置值的平方（配 50% 实际 25%）。
- **语义路径误门控**：语义选图（llm 模式的情感辅助模型预检、tool 模式的提示词注入门控）被 `emotions_probability` 拦截。但语义选图是回复模型/工具基于语义做出的明确决策，用概率随机丢弃既不一致也浪费选图结果；且语义图片固定分离发送，从不走 `mixed_message_probability`。

修复：
- 旧版路径：`_resp_impl` 只掷一次骰，结果存入 extra `meme_manager_legacy_probability_hit`，发送装饰与流式阶段复用，不再二次掷骰；extra 缺失的异常路径回退本地掷骰保持旧行为。情感模型调用受此结果门控（miss 时省去调用）
- 语义路径：移除 llm 模式预检与 tool 模式提示词门控，选图恒附加（工具决策不被概率丢弃）
- 语义图片发送接入 `mixed_message_probability`（合并/分离），与旧版路径一致
- 至此 `emotions_probability` 只作用于旧版路径的"是否附图"；`mixed_message_probability` 作用于两条路径的"合并/分离发送"
