### PR TITLE
test: expand unit coverage across meme manager

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+if str(PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_DIR))
+PLUGIN_PARENT = PLUGIN_DIR.parent
+if str(PLUGIN_PARENT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_PARENT))

--- a/tests/test_category_manager.py
+++ b/tests/test_category_manager.py
@@ -1,0 +1,142 @@
+import json
+
+import pytest
+from astrbot_plugin_meme_manager.backend import category_manager as category_module
+
+
+@pytest.fixture
+def category_context(tmp_path, monkeypatch):
+    pack_dir = tmp_path / "pack"
+    memes_dir = pack_dir / "memes"
+    memes_dir.mkdir(parents=True)
+    metadata_path = pack_dir / "memes_data.json"
+    manifest_path = pack_dir / "manifest.json"
+    metadata_path.write_text(
+        json.dumps({"happy": "开心"}, ensure_ascii=False), encoding="utf-8"
+    )
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "id": "test-pack",
+                "name": "测试包",
+                "version": "1.0.0",
+                "categories": {"happy": {"description": "开心"}},
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    context = {
+        "pack_id": "test-pack",
+        "pack_dir": pack_dir,
+        "memes_dir": memes_dir,
+        "metadata_path": metadata_path,
+        "manifest_path": manifest_path,
+        "category_mapping": {"happy": "开心"},
+    }
+    monkeypatch.setattr(category_module, "resolve_pack_context", lambda: context)
+    return context
+
+
+def test_safe_category_name_and_directory_resolution(category_context):
+    assert category_module.is_safe_category_name("happy")
+    assert not category_module.is_safe_category_name(" happy ")
+    assert not category_module.is_safe_category_name("a/b")
+    assert not category_module.is_safe_category_name("..")
+    assert (
+        category_module.resolve_safe_category_directory(
+            category_context["memes_dir"], "happy"
+        )
+        == (category_context["memes_dir"] / "happy").resolve()
+    )
+
+
+def test_initialization_builds_metadata_from_manifest_and_directories(
+    category_context,
+):
+    category_context["metadata_path"].unlink()
+    (category_context["memes_dir"] / "happy").mkdir()
+    (category_context["memes_dir"] / "sad").mkdir()
+    manager = category_module.CategoryManager()
+    assert manager.descriptions == {"happy": "开心", "sad": "请添加描述"}
+    assert json.loads(
+        category_context["metadata_path"].read_text(encoding="utf-8")
+    ) == (manager.descriptions)
+
+
+def test_create_update_rename_and_delete_category(category_context):
+    manager = category_module.CategoryManager()
+    assert manager.create_category("sad", "伤心")
+    assert (category_context["memes_dir"] / "sad").is_dir()
+    assert manager.update_description("sad", "非常伤心")
+    assert manager.rename_category("sad", "cry")
+    assert not (category_context["memes_dir"] / "sad").exists()
+    assert (category_context["memes_dir"] / "cry").is_dir()
+    assert manager.delete_category("cry")
+    assert not (category_context["memes_dir"] / "cry").exists()
+    assert "cry" not in manager.get_descriptions()
+    manifest = json.loads(category_context["manifest_path"].read_text(encoding="utf-8"))
+    assert set(manifest["categories"]) == {"happy"}
+
+
+def test_category_mutations_reject_invalid_or_conflicting_names(category_context):
+    manager = category_module.CategoryManager()
+    assert not manager.create_category("../bad", "bad")
+    assert not manager.update_description("../bad", "bad")
+    assert not manager.rename_category("missing", "new")
+    assert manager.create_category("sad", "伤心")
+    assert not manager.rename_category("happy", "sad")
+    assert not manager.delete_category("../bad")
+
+
+def test_rename_rejects_existing_target_directory(category_context):
+    manager = category_module.CategoryManager()
+    (category_context["memes_dir"] / "happy").mkdir()
+    (category_context["memes_dir"] / "occupied").mkdir()
+    assert not manager.rename_category("happy", "occupied")
+
+
+def test_remove_from_config_keeps_directory(category_context):
+    manager = category_module.CategoryManager()
+    category_path = category_context["memes_dir"] / "happy"
+    category_path.mkdir()
+    assert manager.remove_from_config("happy")
+    assert category_path.is_dir()
+    assert "happy" not in manager.get_descriptions()
+    assert not manager.remove_from_config("missing")
+    assert not manager.remove_from_config("../bad")
+
+
+def test_sync_status_reports_missing_and_deleted_categories(category_context):
+    manager = category_module.CategoryManager()
+    (category_context["memes_dir"] / "local-only").mkdir()
+    missing_in_config, deleted_categories = manager.get_sync_status()
+    assert missing_in_config == ["local-only"]
+    assert deleted_categories == ["happy"]
+
+
+def test_sync_with_filesystem_aligns_descriptions(category_context):
+    manager = category_module.CategoryManager()
+    (category_context["memes_dir"] / "local-only").mkdir()
+    assert manager.sync_with_filesystem()
+    assert manager.get_descriptions() == {"local-only": "请添加描述"}
+    assert manager.sync_with_filesystem()
+
+
+def test_semantic_invalidation_only_runs_when_metadata_exists(
+    category_context, monkeypatch
+):
+    calls = []
+    monkeypatch.setattr(
+        category_module,
+        "invalidate_semantic_metadata",
+        lambda pack_dir: calls.append(pack_dir),
+    )
+    manager = category_module.CategoryManager()
+    assert manager.update_description("happy", "更开心")
+    assert calls == []
+    (category_context["pack_dir"] / "semantic_metadata.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    assert manager.update_description("happy", "最开心")
+    assert calls == [category_context["pack_dir"].resolve()]

--- a/tests/test_config_runtime.py
+++ b/tests/test_config_runtime.py
@@ -1,0 +1,128 @@
+import json
+
+from astrbot_plugin_meme_manager import config
+
+
+def test_resolve_plugin_name_and_data_directory(monkeypatch, tmp_path):
+    assert config.resolve_plugin_name(None) == config.DEFAULT_PLUGIN_NAME
+    assert config.resolve_plugin_name(" custom ") == "custom"
+    assert config.resolve_plugin_name(" ") == config.DEFAULT_PLUGIN_NAME
+    monkeypatch.setattr(config, "get_astrbot_plugin_data_path", lambda: str(tmp_path))
+    assert config.get_plugin_data_dir("demo") == (tmp_path / "demo").resolve()
+
+
+def test_get_plugin_data_dir_falls_back_when_astrbot_path_fails(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "get_astrbot_plugin_data_path",
+        lambda: (_ for _ in ()).throw(RuntimeError("unavailable")),
+    )
+    expected = (config.PLUGIN_DIR / "data" / "plugin_data" / "demo").resolve()
+    assert config.get_plugin_data_dir("demo") == expected
+
+
+def test_json_file_helpers_and_content_detection(tmp_path):
+    path = tmp_path / "nested" / "data.json"
+    config._save_json_file(path, {"text": "开心"})
+    assert config._load_json_file(path, {}) == {"text": "开心"}
+    path.write_text("not-json", encoding="utf-8")
+    assert config._load_json_file(path, {"fallback": True}) == {"fallback": True}
+    assert not config._plugin_data_dir_has_content(tmp_path / "empty")
+    plugin_data = tmp_path / "plugin"
+    plugin_data.mkdir()
+    (plugin_data / "memes_data.json").write_text("{}", encoding="utf-8")
+    assert config._plugin_data_dir_has_content(plugin_data)
+
+
+def test_copy_directory_contents_merges_without_overwriting(tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    (source / "nested").mkdir(parents=True)
+    target.mkdir()
+    (source / "file.txt").write_text("source", encoding="utf-8")
+    (source / "nested" / "child.txt").write_text("child", encoding="utf-8")
+    (target / "file.txt").write_text("target", encoding="utf-8")
+    config._copy_directory_contents(source, target)
+    assert (target / "file.txt").read_text(encoding="utf-8") == "target"
+    assert (target / "nested" / "child.txt").read_text(encoding="utf-8") == "child"
+
+
+def test_migrate_legacy_data_only_when_target_empty(tmp_path, monkeypatch):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    (legacy / "memes_data.json").write_text('{"happy":"开心"}', encoding="utf-8")
+    target = tmp_path / "target"
+    monkeypatch.setattr(config, "get_legacy_plugin_data_dir", lambda: legacy)
+    config.migrate_legacy_data_dir_if_needed(target)
+    assert (target / "memes_data.json").is_file()
+    (target / "keep.txt").write_text("keep", encoding="utf-8")
+    (legacy / "keep.txt").write_text("overwrite", encoding="utf-8")
+    config.migrate_legacy_data_dir_if_needed(target)
+    assert (target / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_collect_descriptions_combines_metadata_fallback_and_directories(tmp_path):
+    memes_dir = tmp_path / "memes"
+    (memes_dir / "local").mkdir(parents=True)
+    metadata = tmp_path / "memes_data.json"
+    metadata.write_text(
+        json.dumps({"happy": "元数据", "": "忽略"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    result = config._collect_category_descriptions(
+        metadata, memes_dir, {"happy": "默认", "sad": "伤心"}
+    )
+    assert result == {"happy": "元数据", "sad": "伤心", "local": "请添加描述"}
+
+
+def test_pack_manifest_uses_stable_names_and_sorted_categories():
+    manifest = config._build_pack_manifest(
+        config.DEFAULT_PACK_ID, {"sad": "伤心", "happy": "开心"}
+    )
+    assert manifest["name"] == "Builtin Default Meme Pack"
+    assert list(manifest["categories"]) == ["happy", "sad"]
+    legacy = config._build_pack_manifest(config.LEGACY_MIGRATED_PACK_ID, {})
+    assert legacy["name"] == "Migrated Legacy Meme Pack"
+    custom = config._build_pack_manifest("custom", {})
+    assert custom["name"] == "Meme Pack custom"
+
+
+def test_bootstrap_fresh_runtime_creates_builtin_registry_and_rules(tmp_path):
+    config._bootstrap_pack_runtime(tmp_path)
+    builtin = tmp_path / "packs" / config.DEFAULT_PACK_ID
+    assert (builtin / "memes").is_dir()
+    assert (builtin / "manifest.json").is_file()
+    registry = json.loads((tmp_path / "registry.json").read_text(encoding="utf-8"))
+    assert registry["installed_packs"][0]["id"] == config.DEFAULT_PACK_ID
+    rules = json.loads((tmp_path / "selection_rules.json").read_text(encoding="utf-8"))
+    assert rules["rules"][0]["pack_id"] == config.DEFAULT_PACK_ID
+    for directory in ("backup", "migration", "temp"):
+        assert (tmp_path / directory).is_dir()
+
+
+def test_bootstrap_migrates_legacy_root_data(tmp_path):
+    legacy_memes = tmp_path / "memes" / "happy"
+    legacy_memes.mkdir(parents=True)
+    (legacy_memes / "meme.png").write_bytes(b"image")
+    (tmp_path / "memes_data.json").write_text(
+        json.dumps({"happy": "开心"}, ensure_ascii=False), encoding="utf-8"
+    )
+    config._bootstrap_pack_runtime(tmp_path)
+    migrated = tmp_path / "packs" / config.LEGACY_MIGRATED_PACK_ID
+    assert (migrated / "memes" / "happy" / "meme.png").is_file()
+    assert (tmp_path / "migration" / "legacy_runtime_migrated.json").is_file()
+    rules = json.loads((tmp_path / "selection_rules.json").read_text(encoding="utf-8"))
+    assert rules["rules"][0]["pack_id"] == config.LEGACY_MIGRATED_PACK_ID
+
+
+def test_resolve_default_pack_id_prefers_valid_rule_then_legacy(tmp_path):
+    custom = tmp_path / "packs" / "custom"
+    custom.mkdir(parents=True)
+    config._write_default_selection_rules(tmp_path, "custom")
+    assert config._resolve_default_pack_id(tmp_path) == "custom"
+
+    (tmp_path / "selection_rules.json").unlink()
+    legacy_memes = tmp_path / "packs" / config.LEGACY_MIGRATED_PACK_ID / "memes"
+    legacy_memes.mkdir(parents=True)
+    (legacy_memes / "meme.png").write_bytes(b"image")
+    assert config._resolve_default_pack_id(tmp_path) == config.LEGACY_MIGRATED_PACK_ID

--- a/tests/test_img_sync.py
+++ b/tests/test_img_sync.py
@@ -1,0 +1,314 @@
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot_plugin_meme_manager.image_host import img_sync as sync_module
+from astrbot_plugin_meme_manager.image_host.img_sync import ImageSync
+
+
+@pytest.mark.parametrize(
+    ("provider_type", "config", "expected"),
+    [
+        (
+            "stardots",
+            {"key": "key", "secret": "secret", "space": "space"},
+            {
+                "key": "key",
+                "secret": "secret",
+                "space": "space",
+                "local_dir": "images",
+            },
+        ),
+        ("cloudflare_r2", {"account_id": "account"}, {"account_id": "account"}),
+        (
+            "webdav",
+            {"url": "https://dav.example"},
+            {"url": "https://dav.example", "local_dir": "images"},
+        ),
+    ],
+)
+def test_init_selects_provider_and_wires_dependencies(
+    monkeypatch, provider_type, config, expected
+):
+    provider_calls = []
+    tracker_calls = []
+    manager_calls = []
+
+    def provider_factory(value):
+        provider_calls.append(value)
+        return "provider"
+
+    monkeypatch.setattr(sync_module, "StarDotsProvider", provider_factory)
+    monkeypatch.setattr(sync_module, "CloudflareR2Provider", provider_factory)
+    monkeypatch.setattr(sync_module, "WebDAVProvider", provider_factory)
+    monkeypatch.setattr(
+        sync_module,
+        "UploadTracker",
+        lambda path: tracker_calls.append(path) or "tracker",
+    )
+    monkeypatch.setattr(
+        sync_module,
+        "SyncManager",
+        lambda **kwargs: manager_calls.append(kwargs) or "manager",
+    )
+
+    client = ImageSync(config, "images", provider_type)
+    assert provider_calls == [expected]
+    assert tracker_calls[0].name == ".upload_tracker.json"
+    assert manager_calls == [
+        {
+            "image_host": "provider",
+            "local_dir": client.local_dir,
+            "upload_tracker": "tracker",
+        }
+    ]
+    assert client.sync_process is None
+    assert client._sync_task is None
+
+
+def test_init_rejects_unknown_provider(tmp_path):
+    with pytest.raises(ValueError):
+        ImageSync({}, tmp_path, "unknown")
+
+
+def make_client(status=None):
+    client = object.__new__(ImageSync)
+    client.config = {"key": "key"}
+    client.local_dir = sync_module.Path("images")
+    client.provider = SimpleNamespace()
+    client.sync_manager = SimpleNamespace(
+        check_sync_status=lambda: status or {"to_upload": [], "to_download": []}
+    )
+    client.sync_process = None
+    client._sync_task = None
+    return client
+
+
+def test_status_and_remote_operations_delegate_to_collaborators():
+    status = {"to_upload": [{"filename": "a.png"}]}
+    client = make_client(status)
+    calls = []
+    client.provider = SimpleNamespace(
+        get_image_list=lambda: [{"filename": "remote.png"}],
+        delete_image=lambda filename: calls.append(filename) or True,
+    )
+    assert client.check_status() == status
+    assert client.get_remote_files() == [{"filename": "remote.png"}]
+    assert client.delete_remote_file("remote.png")
+    assert calls == ["remote.png"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("task", "status"),
+    [
+        ("upload", {"to_upload": []}),
+        ("download", {"to_download": []}),
+        ("overwrite_to_remote", {"to_upload": [], "to_delete_remote": []}),
+        (
+            "overwrite_from_remote",
+            {"to_download": [], "to_delete_local": []},
+        ),
+    ],
+)
+async def test_start_sync_skips_tasks_without_work(task, status):
+    client = make_client(status)
+    assert await client.start_sync(task)
+    assert client.sync_process is None
+
+
+@pytest.mark.asyncio
+async def test_start_sync_rejects_concurrent_process():
+    client = make_client()
+    client.sync_process = SimpleNamespace(is_alive=lambda: True)
+    with pytest.raises(RuntimeError):
+        await client.start_sync("upload")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("exitcode", "expected"), [(0, True), (2, False)])
+async def test_start_sync_waits_for_worker_exit(monkeypatch, exitcode, expected):
+    client = make_client({"to_upload": [{"filename": "a.png"}]})
+
+    class FakeProcess:
+        def __init__(self, target, args):
+            self.target = target
+            self.args = args
+            self.exitcode = exitcode
+            self.started = False
+            self.joined = False
+
+        def start(self):
+            self.started = True
+
+        def join(self):
+            self.joined = True
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setattr(sync_module.multiprocessing, "Process", FakeProcess)
+    assert await client.start_sync("upload") is expected
+    assert client.sync_process.started
+    assert client.sync_process.joined
+
+
+def test_stop_sync_terminates_stubborn_process_and_cancels_waiter():
+    class FakeProcess:
+        alive = True
+        terminated = False
+        killed = False
+
+        def is_alive(self):
+            return self.alive
+
+        def terminate(self):
+            self.terminated = True
+
+        def join(self, timeout=None):
+            return None
+
+        def kill(self):
+            self.killed = True
+            self.alive = False
+
+    class FakeTask:
+        cancelled = False
+
+        def done(self):
+            return False
+
+        def cancel(self):
+            self.cancelled = True
+
+    client = make_client()
+    process = FakeProcess()
+    task = FakeTask()
+    client.sync_process = process
+    client._sync_task = task
+    client.stop_sync()
+    assert process.terminated
+    assert process.killed
+    assert task.cancelled
+    assert client.sync_process is None
+    assert client._sync_task is None
+
+
+def test_upload_and_download_start_expected_worker():
+    client = make_client()
+    calls = []
+    client._start_sync_process = lambda task: calls.append(task) or f"process-{task}"
+    assert client.upload_to_remote() == "process-upload"
+    assert client.download_to_local() == "process-download"
+    assert calls == ["upload", "download"]
+
+
+def test_start_sync_process_constructs_and_starts_process(monkeypatch):
+    client = make_client()
+
+    class FakeProcess:
+        def __init__(self, target, args):
+            self.target = target
+            self.args = args
+            self.started = False
+
+        def start(self):
+            self.started = True
+
+    monkeypatch.setattr(sync_module.multiprocessing, "Process", FakeProcess)
+    process = client._start_sync_process("download")
+    assert process.target is sync_module.run_sync_process
+    assert process.args == (client.config, "images", "download")
+    assert process.started
+
+
+@pytest.mark.parametrize(
+    ("config", "expected_type", "expected_config"),
+    [
+        ({"cloudflare_r2": {"account_id": "a"}}, "cloudflare_r2", {"account_id": "a"}),
+        ({"stardots": {"key": "k"}}, "stardots", {"key": "k"}),
+        ({"webdav": {"url": "u"}}, "webdav", {"url": "u"}),
+        ({"account_id": "a"}, "cloudflare_r2", {"account_id": "a"}),
+        ({"key": "k"}, "stardots", {"key": "k"}),
+        (
+            {"provider": "webdav", "url": "u"},
+            "webdav",
+            {"provider": "webdav", "url": "u"},
+        ),
+    ],
+)
+def test_run_sync_process_detects_provider(
+    monkeypatch, config, expected_type, expected_config
+):
+    calls = []
+    sync = SimpleNamespace(
+        sync_manager=SimpleNamespace(sync_to_remote=lambda: calls.append("upload") or True)
+    )
+    monkeypatch.setattr(
+        sync_module,
+        "ImageSync",
+        lambda provider_config, local_dir, provider_type: (
+            calls.append((provider_config, local_dir, provider_type)) or sync
+        ),
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        sync_module.run_sync_process(config, "images", "upload")
+    assert exc_info.value.code == 0
+    assert calls == [(expected_config, "images", expected_type), "upload"]
+
+
+@pytest.mark.parametrize(
+    ("task", "method", "success", "exitcode"),
+    [
+        ("upload", "sync_to_remote", False, 1),
+        ("download", "sync_from_remote", True, 0),
+        ("overwrite_to_remote", "overwrite_to_remote", True, 0),
+        ("overwrite_from_remote", "overwrite_from_remote", False, 1),
+    ],
+)
+def test_run_sync_process_dispatches_task(
+    monkeypatch, task, method, success, exitcode
+):
+    calls = []
+    manager = SimpleNamespace(**{method: lambda: calls.append(method) or success})
+    monkeypatch.setattr(
+        sync_module,
+        "ImageSync",
+        lambda *args: SimpleNamespace(sync_manager=manager),
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        sync_module.run_sync_process({"key": "key"}, "images", task)
+    assert exc_info.value.code == exitcode
+    assert calls == [method]
+
+
+def test_run_sync_process_runs_full_sync_in_order(monkeypatch):
+    calls = []
+    manager = SimpleNamespace(
+        sync_to_remote=lambda: calls.append("upload") or True,
+        sync_from_remote=lambda: calls.append("download") or True,
+    )
+    monkeypatch.setattr(
+        sync_module,
+        "ImageSync",
+        lambda *args: SimpleNamespace(sync_manager=manager),
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        sync_module.run_sync_process({"key": "key"}, "images", "sync_all")
+    assert exc_info.value.code == 0
+    assert calls == ["upload", "download"]
+
+
+@pytest.mark.parametrize(
+    ("config", "task"),
+    [({}, "upload"), ({"key": "key"}, "unknown")],
+)
+def test_run_sync_process_rejects_unknown_config_or_task(monkeypatch, config, task):
+    monkeypatch.setattr(
+        sync_module,
+        "ImageSync",
+        lambda *args: SimpleNamespace(sync_manager=SimpleNamespace()),
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        sync_module.run_sync_process(config, "images", task)
+    assert exc_info.value.code == 1

--- a/tests/test_init_and_main_helpers.py
+++ b/tests/test_init_and_main_helpers.py
@@ -1,0 +1,242 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot_plugin_meme_manager import init as plugin_init
+from astrbot_plugin_meme_manager.main import MemeSender
+
+
+@pytest.fixture
+def init_paths(tmp_path, monkeypatch):
+    base = tmp_path / "data"
+    memes = base / "memes"
+    metadata = base / "memes_data.json"
+    manifest = base / "manifest.json"
+    monkeypatch.setattr(plugin_init, "BASE_DATA_DIR", str(base))
+    monkeypatch.setattr(plugin_init, "MEMES_DIR", str(memes))
+    monkeypatch.setattr(plugin_init, "MEMES_DATA_PATH", str(metadata))
+    monkeypatch.setattr(plugin_init, "ACTIVE_PACK_MANIFEST_PATH", manifest)
+    sync_calls = []
+    monkeypatch.setattr(
+        plugin_init,
+        "sync_active_pack_metadata",
+        lambda: sync_calls.append(True),
+    )
+    return base, memes, metadata, manifest, sync_calls
+
+
+def test_init_plugin_builds_descriptions_from_manifest_and_directories(init_paths):
+    _, memes, metadata, manifest, sync_calls = init_paths
+    (memes / "happy").mkdir(parents=True)
+    (memes / "local").mkdir()
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "categories": {
+                    "happy": {"description": "happy description"},
+                    "missing": {"description": "missing description"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert plugin_init.init_plugin()
+    assert json.loads(metadata.read_text(encoding="utf-8")) == {
+        "happy": "happy description",
+        "local": "请添加描述",
+    }
+    assert sync_calls == [True]
+
+
+def test_init_plugin_normalizes_existing_descriptions(init_paths):
+    _, memes, metadata, _, sync_calls = init_paths
+    (memes / "happy").mkdir(parents=True)
+    (memes / "new").mkdir()
+    metadata.write_text(
+        json.dumps({"happy": "existing", "stale": "orphan"}),
+        encoding="utf-8",
+    )
+
+    assert plugin_init.init_plugin()
+    assert json.loads(metadata.read_text(encoding="utf-8")) == {
+        "happy": "existing",
+        "new": "请添加描述",
+    }
+    assert sync_calls == [True]
+
+
+def test_init_plugin_reports_outer_failure(init_paths, monkeypatch):
+    monkeypatch.setattr(
+        plugin_init,
+        "ensure_dir_exists",
+        lambda path: (_ for _ in ()).throw(OSError("disk")),
+    )
+
+    assert not plugin_init.init_plugin()
+
+
+def make_sender(config=None):
+    sender = object.__new__(MemeSender)
+    sender.config = config or {}
+    return sender
+
+
+def test_main_config_reading_prefers_modern_then_legacy_values():
+    sender = make_sender(
+        {
+            "storage": {"provider": "webdav", "providers": {"r2": {"key": "new"}}},
+            "image_host": "stardots",
+            "image_host_config": {"r2": {"key": "old", "secret": "legacy"}},
+            "legacy_value": 3,
+        }
+    )
+
+    assert sender._read_path(("storage", "provider")) == "webdav"
+    assert sender._read_path(("missing",), "fallback") == "fallback"
+    assert sender._read_config_value(
+        ("storage", "missing"), default=1, legacy_keys=("legacy_value",)
+    ) == 3
+    assert sender._get_provider_config("r2") == {"key": "new", "secret": "legacy"}
+    assert sender._get_nested_config("storage", "providers", "r2") == {"key": "new"}
+    assert sender._get_nested_config("storage", "missing") == {}
+    assert sender._has_required_config({"a": 1, "b": "x"}, ["a", "b"])
+    assert not sender._has_required_config({"a": 1, "b": ""}, ["a", "b"])
+
+
+def test_main_image_host_type_supports_string_and_object_config():
+    assert make_sender({"storage": {"provider": "WebDAV"}})._get_image_host_type() == (
+        "webdav"
+    )
+    assert make_sender(
+        {"storage": {"provider": {"name": "CloudFlare_R2"}}}
+    )._get_image_host_type() == "cloudflare_r2"
+    assert make_sender({})._get_image_host_type() == "stardots"
+
+
+def test_main_webdav_aliases_are_normalized():
+    sender = make_sender(
+        {
+            "storage": {
+                "providers": {
+                    "webdav": {
+                        "webdav_url": "https://dav.example",
+                        "user": "name",
+                        "token": "secret",
+                        "remote_path": "memes",
+                        "ssl_verify": False,
+                    }
+                }
+            }
+        }
+    )
+
+    result = sender._get_webdav_config()
+    assert result["url"] == "https://dav.example"
+    assert result["username"] == "name"
+    assert result["password"] == "secret"
+    assert result["base_path"] == "memes"
+    assert result["verify_ssl"] is False
+
+
+def test_main_prompt_build_wrap_and_strip_round_trip():
+    sender = make_sender()
+    sender.category_mapping_string = "happy - 开心"
+    sender.prompt_head = "请选择："
+    sender.prompt_tail_1 = "，最多"
+    sender.max_emotions_per_message = 2
+    sender.prompt_tail_2 = "个。"
+    sender.sys_prompt_add = ""
+
+    prompt = sender._build_meme_prompt()
+    assert prompt == "请选择：happy - 开心，最多2个。"
+    wrapped = sender._wrap_meme_prompt(prompt)
+    assert sender._strip_meme_prompt("基础提示" + wrapped) == "基础提示"
+    semantic = "基础" + sender._semantic_system_prompt()
+    assert sender._strip_meme_prompt(semantic) == "基础"
+
+
+def test_main_semantic_mode_requires_matching_verified_pack():
+    sender = make_sender()
+
+    class Event:
+        def __init__(self, values):
+            self.values = values
+
+        def get_extra(self, key):
+            return self.values.get(key)
+
+    assert sender._semantic_mode_active(
+        Event(
+            {
+                "meme_manager_semantic_active": True,
+                "meme_manager_semantic_verified_pack_id": "pack-a",
+                "meme_manager_runtime_pack_id": "pack-a",
+            }
+        )
+    )
+    assert not sender._semantic_mode_active(
+        Event(
+            {
+                "meme_manager_semantic_active": True,
+                "meme_manager_semantic_verified_pack_id": "pack-a",
+                "meme_manager_runtime_pack_id": "pack-b",
+            }
+        )
+    )
+    assert not sender._semantic_mode_active(None)
+
+
+def test_main_persona_resolution_and_base_prompt_tracking():
+    sender = make_sender()
+    sender.prompt_head = "请选择："
+    sender.prompt_tail_2 = "个。"
+    sender.sys_prompt_add = ""
+    sender.persona_base_prompts = {}
+    request = SimpleNamespace(
+        conversation=SimpleNamespace(persona_id="persona-from-request")
+    )
+
+    assert sender._resolve_persona_id(req=request) == "persona-from-request"
+    event = SimpleNamespace(persona_id="event-persona")
+    assert sender._resolve_persona_id(event=event) == "event-persona"
+    personas = [
+        {"name": "one", "prompt": "base prompt"},
+        {"id": "two", "prompt": "second prompt"},
+    ]
+    sender._sync_persona_base_prompts(personas)
+    assert sender.persona_base_prompts == {
+        "one": "base prompt",
+        "two": "second prompt",
+    }
+    sender._sync_persona_base_prompts([personas[0]])
+    assert sender.persona_base_prompts == {"one": "base prompt"}
+
+
+def test_main_manageable_categories_and_default_description_updates():
+    sender = make_sender()
+
+    class Manager:
+        descriptions = {"happy": "existing"}
+        local = {"happy", "sad"}
+
+        def get_descriptions(self):
+            return dict(self.descriptions)
+
+        def get_local_categories(self):
+            return set(self.local)
+
+        def update_description(self, category, description):
+            self.descriptions[category] = description
+            return True
+
+    sender.category_manager = Manager()
+    reloads = []
+    sender._reload_personas = lambda: reloads.append(True)
+
+    assert sender._get_manageable_categories() == {"happy", "sad"}
+    sender._ensure_default_category_descriptions(["happy", "sad", "unknown"])
+    assert sender.category_manager.descriptions["sad"]
+    assert reloads == [True]

--- a/tests/test_mixins_helpers.py
+++ b/tests/test_mixins_helpers.py
@@ -1,0 +1,278 @@
+import base64
+import json
+from types import SimpleNamespace
+
+import pytest
+from astrbot_plugin_meme_manager.mixins.commands import CommandMixin
+from astrbot_plugin_meme_manager.mixins.event_handlers import (
+    LLM_REQUEST_ORIGIN_CHAT,
+    LLM_REQUEST_ORIGIN_EXTRA_KEY,
+    LLM_REQUEST_ORIGIN_PLUGIN,
+    TRIGGER_SCOPE_CHAT_AND_PLUGIN,
+    TRIGGER_SCOPE_CHAT_ONLY,
+    EventHandlerMixin,
+    normalize_trigger_scope,
+)
+from astrbot_plugin_meme_manager.mixins.web_api import WebAPIMixin
+
+from astrbot.api.message_components import Plain
+
+
+class FakeEvent:
+    def __init__(self, message=""):
+        self.message = message
+        self.extra = {}
+
+    def get_message_str(self):
+        return self.message
+
+    def get_extra(self, key):
+        return self.extra.get(key)
+
+    def set_extra(self, key, value):
+        self.extra[key] = value
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, TRIGGER_SCOPE_CHAT_ONLY),
+        ("only_chat_llm", TRIGGER_SCOPE_CHAT_ONLY),
+        ("all_llm", TRIGGER_SCOPE_CHAT_AND_PLUGIN),
+        ("all_messages", TRIGGER_SCOPE_CHAT_AND_PLUGIN),
+        ("chat_and_plugin_llm", TRIGGER_SCOPE_CHAT_AND_PLUGIN),
+        ("invalid", TRIGGER_SCOPE_CHAT_ONLY),
+    ],
+)
+def test_normalize_trigger_scope(value, expected):
+    assert normalize_trigger_scope(value) == expected
+
+
+@pytest.mark.asyncio
+async def test_mark_and_filter_llm_request_origin():
+    mixin = object.__new__(EventHandlerMixin)
+    event = FakeEvent()
+    await mixin._mark_llm_request_origin_impl(event)
+    assert event.extra[LLM_REQUEST_ORIGIN_EXTRA_KEY] == LLM_REQUEST_ORIGIN_CHAT
+    mixin.trigger_scope = TRIGGER_SCOPE_CHAT_ONLY
+    assert mixin._scope_allows_llm_origin(event)
+
+    event.extra["provider_request"] = object()
+    await mixin._mark_llm_request_origin_impl(event)
+    assert event.extra[LLM_REQUEST_ORIGIN_EXTRA_KEY] == LLM_REQUEST_ORIGIN_PLUGIN
+    assert not mixin._scope_allows_llm_origin(event)
+    mixin.trigger_scope = TRIGGER_SCOPE_CHAT_AND_PLUGIN
+    assert mixin._scope_allows_llm_origin(event)
+
+
+def test_should_attach_for_llm_and_streaming_results():
+    mixin = object.__new__(EventHandlerMixin)
+    mixin.trigger_scope = TRIGGER_SCOPE_CHAT_ONLY
+    event = FakeEvent()
+    event.extra[LLM_REQUEST_ORIGIN_EXTRA_KEY] = LLM_REQUEST_ORIGIN_CHAT
+    assert not mixin._should_attach_for_result(event, None)
+    assert mixin._should_attach_for_result(
+        event, SimpleNamespace(result_content_type="STREAMING_FINISH")
+    )
+    assert mixin._should_attach_for_result(
+        event,
+        SimpleNamespace(result_content_type="OTHER", is_llm_result=lambda: True),
+    )
+    assert not mixin._should_attach_for_result(
+        event,
+        SimpleNamespace(result_content_type="OTHER", is_llm_result=lambda: False),
+    )
+
+
+def test_emotion_context_text_role_and_content_helpers():
+    mixin = EventHandlerMixin
+    assert mixin._stringify_emotion_context_text(None) == ""
+    assert mixin._stringify_emotion_context_text(["hello", {"text": "world"}]) == (
+        "hello world"
+    )
+    assert (
+        mixin._stringify_emotion_context_text({"unknown": "值"}) == '{"unknown": "值"}'
+    )
+    assert mixin._extract_emotion_context_role({"sender": " USER "}) == "user"
+    assert mixin._extract_emotion_context_role(SimpleNamespace(role="Assistant")) == (
+        "assistant"
+    )
+    assert mixin._extract_emotion_context_content({"message": {"text": "消息"}}) == (
+        "消息"
+    )
+    assert mixin._extract_emotion_context_content(SimpleNamespace(content="回复")) == (
+        "回复"
+    )
+
+
+def test_collect_emotion_context_filters_roles_and_limits_turns():
+    mixin = object.__new__(EventHandlerMixin)
+    mixin.emotion_llm_context_turns = 1
+    request = SimpleNamespace(
+        contexts=json.dumps(
+            [
+                {"role": "system", "content": "系统"},
+                {"role": "user", "content": "第一条"},
+                {"role": "assistant", "content": "第二条"},
+                {"role": "user", "content": "第三条"},
+            ],
+            ensure_ascii=False,
+        )
+    )
+    assert mixin._collect_emotion_context_lines_from_request(request) == [
+        "助手: 第二条",
+        "用户: 第三条",
+    ]
+    mixin.emotion_llm_context_turns = 0
+    assert mixin._collect_emotion_context_lines_from_request(request) == []
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('{"emotions":["happy","HAPPY","bad",3]}', ["happy"]),
+        ('prefix ["sad", "happy"] suffix', ["sad", "happy"]),
+        ('{"tag":"&&happy&&"}', ["happy"]),
+        ("not-json", []),
+        ("", []),
+    ],
+)
+def test_parse_emotion_llm_selection(raw, expected):
+    assert (
+        EventHandlerMixin._parse_emotion_llm_selection(raw, {"happy", "sad"})
+        == expected
+    )
+
+
+def test_filter_emotion_selection_deduplicates_and_applies_optional_limit():
+    mixin = object.__new__(EventHandlerMixin)
+    mixin.max_emotions_per_message = 2
+    mixin.strict_max_emotions_per_message = True
+    assert mixin._filter_emotion_selection(["happy", "happy", "sad", "angry"]) == [
+        "happy",
+        "sad",
+    ]
+    mixin.strict_max_emotions_per_message = False
+    assert mixin._filter_emotion_selection(["happy", "sad", "angry"]) == [
+        "happy",
+        "sad",
+        "angry",
+    ]
+
+
+def test_marked_emotion_extraction_and_text_cleanup():
+    mixin = object.__new__(EventHandlerMixin)
+    mixin.remove_invalid_alternative_markup = False
+    mixin._read_config_value = lambda *args, **kwargs: True
+    cleaned, emotions = mixin._extract_marked_emotions_from_text(
+        "你好 &&happy&& [sad] (happy) [unknown]", {"happy", "sad"}
+    )
+    assert emotions == ["happy", "sad", "happy"]
+    assert "&&" not in cleaned
+    assert "[unknown]" in cleaned
+
+
+def test_emotion_markup_context_heuristics():
+    mixin = object.__new__(EventHandlerMixin)
+    mixin._read_config_value = lambda *args, **kwargs: ["special"]
+    text = "before <thinking>happy</thinking> after"
+    assert mixin._is_position_in_thinking_tags(text, text.index("happy"))
+    assert not mixin._is_position_in_thinking_tags(text, 0)
+    assert not mixin._is_likely_emotion_markup("[1]", "value [1] value", 6)
+    assert not mixin._is_likely_emotion_markup("(two words)", "(two words)", 0)
+    assert mixin._is_likely_emotion_markup("(happy)", "你好(happy)", 2)
+    assert mixin._is_likely_emotion("happy", "你好happy", 2, {"happy"})
+    assert mixin._is_likely_emotion("special", "xspecialx", 1, {"special"})
+
+
+def test_merge_components_distributes_images_after_plain_components():
+    mixin = object.__new__(EventHandlerMixin)
+    first = Plain("first")
+    second = Plain("second")
+    image_one = object()
+    image_two = object()
+    assert mixin._merge_components_with_images([first], []) == [first]
+    assert mixin._merge_components_with_images([], [image_one]) == [image_one]
+    assert mixin._merge_components_with_images([object()], [image_one])[-1] is image_one
+    merged = mixin._merge_components_with_images(
+        [first, second], [image_one, image_two]
+    )
+    assert merged == [first, image_one, second, image_two]
+
+
+def test_command_description_and_category_count_helpers():
+    mixin = object.__new__(CommandMixin)
+    event = FakeEvent("表情管理   添加分类 happy   表示开心")
+    assert mixin._extract_category_description_from_command(event, "happy") == (
+        "表示开心"
+    )
+    assert (
+        mixin._extract_category_description_from_command(
+            FakeEvent("其他命令 happy 描述"), "happy"
+        )
+        == ""
+    )
+    assert (
+        mixin._extract_category_description_from_command(
+            FakeEvent("表情管理 添加分类 happy"), "happy"
+        )
+        == ""
+    )
+    assert mixin._format_category_counts({"empty": 0}) == "无可删除的表情包文件。"
+    summary = mixin._format_category_counts(
+        {f"category-{index}": 1 for index in range(10)}, limit=2
+    )
+    assert summary.count("个") == 3
+    assert "其余 8 个类型已省略" in summary
+
+
+def test_web_api_response_status_and_safe_image_name():
+    assert WebAPIMixin._get_webui_response_status(({}, 201)) == 201
+    assert (
+        WebAPIMixin._get_webui_response_status(SimpleNamespace(status_code=204)) == 204
+    )
+    assert WebAPIMixin._get_webui_response_status(object()) == "unknown"
+    assert WebAPIMixin._safe_semantic_image_name("meme.png")
+    for value in ("", ".", "..", "../meme.png", "nested/meme.png", "a\\b.png"):
+        assert not WebAPIMixin._safe_semantic_image_name(value)
+
+
+def test_web_api_scan_and_description_loading(tmp_path):
+    pack_dir = tmp_path / "pack"
+    memes_dir = pack_dir / "memes"
+    (memes_dir / "happy").mkdir(parents=True)
+    (memes_dir / "happy" / "meme.png").write_bytes(b"image")
+    (memes_dir / "happy" / "ignore.txt").write_bytes(b"ignore")
+    assert WebAPIMixin._scan_pack_emojis(memes_dir) == {"happy": ["meme.png"]}
+    assert WebAPIMixin._scan_pack_emojis(tmp_path / "missing") == {}
+
+    metadata_path = pack_dir / "memes_data.json"
+    manifest_path = pack_dir / "manifest.json"
+    metadata_path.write_text(
+        json.dumps({"happy": "元数据"}, ensure_ascii=False), encoding="utf-8"
+    )
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "categories": {
+                    "happy": {"description": "清单"},
+                    "sad": {"description": "伤心"},
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    descriptions = WebAPIMixin._load_pack_descriptions(
+        {"memes_data_path": metadata_path, "manifest_path": manifest_path}
+    )
+    assert descriptions == {"happy": "元数据", "sad": "伤心"}
+
+
+def test_web_api_build_file_data_url(tmp_path):
+    path = tmp_path / "image.png"
+    path.write_bytes(b"image")
+    result = WebAPIMixin._build_file_data_url(path, "image/png")
+    assert result == "data:image/png;base64," + base64.b64encode(b"image").decode(
+        "ascii"
+    )

--- a/tests/test_models_operations.py
+++ b/tests/test_models_operations.py
@@ -1,0 +1,204 @@
+import io
+from pathlib import Path
+
+import pytest
+from astrbot_plugin_meme_manager.backend import models
+
+
+class UploadedFile:
+    def __init__(self, filename, content):
+        self.filename = filename
+        self.stream = io.BytesIO(content)
+
+
+class SavedFile:
+    def __init__(self, filename, content):
+        self.filename = filename
+        self.content = content
+
+    def save(self, target):
+        Path(target).write_bytes(self.content)
+
+
+@pytest.fixture
+def memes_root(tmp_path, monkeypatch):
+    root = tmp_path / "memes"
+    root.mkdir()
+    monkeypatch.setattr(models, "resolve_pack_context", lambda: {"memes_dir": root})
+    return root
+
+
+def test_supported_image_and_available_filename_helpers(tmp_path):
+    assert models._is_supported_image("meme.PNG")
+    assert not models._is_supported_image("meme.txt")
+    assert models._iter_category_image_paths(tmp_path) == []
+    (tmp_path / "a.png").write_bytes(b"a")
+    (tmp_path / "b.txt").write_bytes(b"b")
+    assert models._iter_category_image_paths(tmp_path) == [tmp_path / "a.png"]
+    assert models._build_available_file_path(tmp_path, "a.png") == tmp_path / "a_1.png"
+    (tmp_path / "a_1.png").write_bytes(b"a")
+    assert models._build_available_file_path(tmp_path, "a.png") == tmp_path / "a_2.png"
+
+
+@pytest.mark.asyncio
+async def test_scan_emoji_folder_filters_files(memes_root):
+    happy = memes_root / "happy"
+    happy.mkdir()
+    (happy / "one.png").write_bytes(b"one")
+    (happy / "ignore.txt").write_bytes(b"ignore")
+    (memes_root / "root.png").write_bytes(b"root")
+    assert await models.scan_emoji_folder() == {"happy": ["one.png"]}
+
+
+def test_add_emoji_handles_duplicate_content_and_filename_collision(memes_root):
+    first = models.add_emoji_to_category("happy", UploadedFile("same.png", b"one"))
+    second = models.add_emoji_to_category("happy", UploadedFile("same.png", b"two"))
+    assert first["filename"] == "same.png"
+    assert second["filename"] == "same_1.png"
+    assert sorted(models.get_emoji_by_category("happy")) == ["same.png", "same_1.png"]
+    with pytest.raises(models.DuplicateEmojiError) as error:
+        models.add_emoji_to_category("happy", UploadedFile("copy.png", b"one"))
+    assert error.value.existing_filename == "same.png"
+
+
+@pytest.mark.parametrize(
+    "uploaded_file",
+    [None, UploadedFile("", b"image"), UploadedFile("meme.png", b"")],
+)
+def test_add_emoji_rejects_missing_upload_data(memes_root, uploaded_file):
+    expected_error = (
+        ValueError if uploaded_file is None or not uploaded_file.filename else OSError
+    )
+    with pytest.raises(expected_error):
+        models.add_emoji_to_category("happy", uploaded_file)
+
+
+def test_delete_and_batch_delete_report_results(memes_root):
+    category = memes_root / "happy"
+    category.mkdir()
+    (category / "one.png").write_bytes(b"one")
+    (category / "two.webp").write_bytes(b"two")
+    (category / "ignore.txt").write_bytes(b"ignore")
+    assert models.delete_emoji_from_category("happy", "../one.png")
+    assert not models.delete_emoji_from_category("happy", "missing.png")
+    result = models.batch_delete_emojis(
+        "happy", ["two.webp", "two.webp", "missing.png"]
+    )
+    assert result["deleted_files"] == ["two.webp"]
+    assert result["missing_files"] == ["missing.png"]
+    assert (
+        models.batch_delete_emojis("missing", ["one.png"])["category_exists"] is False
+    )
+
+
+def test_move_emoji_success_missing_conflict_and_missing_source(memes_root):
+    source = memes_root / "source"
+    target = memes_root / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "move.png").write_bytes(b"move")
+    result = models.move_emoji_to_category("source", "move.png", "target")
+    assert result["moved"]
+    assert (target / "move.png").is_file()
+
+    (source / "conflict.png").write_bytes(b"source")
+    (target / "conflict.png").write_bytes(b"target")
+    assert models.move_emoji_to_category("source", "conflict.png", "target")["conflict"]
+    assert models.move_emoji_to_category("source", "missing.png", "target")["missing"]
+    assert not models.move_emoji_to_category("missing", "x.png", "target")[
+        "source_category_exists"
+    ]
+
+
+def test_batch_move_deduplicates_and_groups_outcomes(memes_root):
+    source = memes_root / "source"
+    target = memes_root / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "move.png").write_bytes(b"move")
+    (source / "conflict.png").write_bytes(b"source")
+    (target / "conflict.png").write_bytes(b"target")
+    result = models.batch_move_emojis(
+        "source", ["move.png", "move.png", "conflict.png", "missing.png"], "target"
+    )
+    assert result["moved_files"] == ["move.png"]
+    assert result["conflicting_files"] == ["conflict.png"]
+    assert result["missing_files"] == ["missing.png"]
+    assert not models.batch_move_emojis("missing", [], "target")[
+        "source_category_exists"
+    ]
+
+
+def test_copy_and_batch_copy_keep_source_files(memes_root):
+    source = memes_root / "source"
+    target = memes_root / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "copy.png").write_bytes(b"copy")
+    assert models.copy_emoji_to_category("source", "copy.png", "target")["copied"]
+    assert (source / "copy.png").is_file()
+    assert (target / "copy.png").is_file()
+    assert models.copy_emoji_to_category("source", "copy.png", "target")["conflict"]
+    assert models.copy_emoji_to_category("source", "missing.png", "target")["missing"]
+    assert not models.copy_emoji_to_category("missing", "x.png", "target")[
+        "source_category_exists"
+    ]
+
+    (source / "second.png").write_bytes(b"second")
+    result = models.batch_copy_emojis(
+        "source", ["second.png", "second.png", "copy.png", "missing.png"], "target"
+    )
+    assert result["copied_files"] == ["second.png"]
+    assert result["conflicting_files"] == ["copy.png"]
+    assert result["missing_files"] == ["missing.png"]
+    assert not models.batch_copy_emojis("missing", [], "target")[
+        "source_category_exists"
+    ]
+
+
+def test_clear_category_and_all_keep_directories_and_non_images(memes_root):
+    for category_name in ("happy", "sad"):
+        category = memes_root / category_name
+        category.mkdir()
+        (category / "meme.png").write_bytes(b"image")
+        (category / "note.txt").write_bytes(b"note")
+    result = models.clear_category_emojis("happy")
+    assert result == {"category_exists": True, "deleted_files": ["meme.png"]}
+    assert (memes_root / "happy" / "note.txt").is_file()
+    assert models.clear_category_emojis("missing")["category_exists"] is False
+
+    result = models.clear_all_emojis()
+    assert result == {"deleted_by_category": {"sad": 1}}
+    assert (memes_root / "sad").is_dir()
+
+
+def test_clear_all_handles_missing_root(tmp_path, monkeypatch):
+    missing = tmp_path / "missing"
+    monkeypatch.setattr(models, "resolve_pack_context", lambda: {"memes_dir": missing})
+    assert models.clear_all_emojis() == {"deleted_by_category": {}}
+
+
+def test_update_emoji_replaces_supported_file(memes_root):
+    category = memes_root / "happy"
+    category.mkdir()
+    (category / "old.png").write_bytes(b"old")
+    assert models.update_emoji_in_category(
+        "happy", "old.png", SavedFile("new.webp", b"new")
+    )
+    assert not (category / "old.png").exists()
+    assert (category / "new.webp").read_bytes() == b"new"
+    assert not models.update_emoji_in_category(
+        "happy", "missing.png", SavedFile("new.png", b"new")
+    )
+    assert not models.update_emoji_in_category(
+        "missing", "old.png", SavedFile("new.png", b"new")
+    )
+
+
+@pytest.mark.parametrize("filename", ["", "bad.txt", "中文.png"])
+def test_update_emoji_rejects_unsafe_new_filename(memes_root, filename):
+    category = memes_root / "happy"
+    category.mkdir()
+    (category / "old.png").write_bytes(b"old")
+    with pytest.raises(ValueError):
+        models.update_emoji_in_category("happy", "old.png", SavedFile(filename, b"new"))

--- a/tests/test_pack_protocol.py
+++ b/tests/test_pack_protocol.py
@@ -1,0 +1,243 @@
+import json
+
+import pytest
+from backend import pack_protocol as protocol
+
+
+def valid_manifest(**overrides):
+    manifest = {
+        "id": "test-pack",
+        "name": "测试资源包",
+        "version": "1.0.0",
+        "categories": {"happy": {"description": "开心"}},
+    }
+    manifest.update(overrides)
+    return manifest
+
+
+@pytest.mark.parametrize("pack_id", ["ab", "pack-name", "pack_name", "pack.name", "a1"])
+def test_validate_pack_id_accepts_stable_ids(pack_id):
+    assert protocol.validate_pack_id(pack_id) == pack_id
+
+
+@pytest.mark.parametrize(
+    "pack_id",
+    ["", "a", "A-pack", "有中文", "with space", "slash/name", "x" * 65],
+)
+def test_validate_pack_id_rejects_invalid_ids(pack_id):
+    with pytest.raises(ValueError):
+        protocol.validate_pack_id(pack_id)
+
+
+def test_validate_transfer_manifest_normalizes_optional_fields():
+    result = protocol.validate_transfer_manifest(
+        {
+            "format": protocol.PACK_TRANSFER_FORMAT,
+            "format_version": "2",
+            "export_mode": " BACKUP ",
+            "features": {"semantic_metadata": 1, "vectors": 0, "ignored": True},
+        }
+    )
+    assert result["format_version"] == 2
+    assert result["export_mode"] == "backup"
+    assert result["features"] == {"semantic_metadata": True, "vectors": False}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {},
+        {"format": "wrong"},
+        {"format": protocol.PACK_TRANSFER_FORMAT, "format_version": "bad"},
+        {"format": protocol.PACK_TRANSFER_FORMAT, "format_version": 99},
+        {
+            "format": protocol.PACK_TRANSFER_FORMAT,
+            "format_version": 1,
+            "export_mode": "invalid",
+        },
+        {
+            "format": protocol.PACK_TRANSFER_FORMAT,
+            "format_version": 1,
+            "features": [],
+        },
+    ],
+)
+def test_validate_transfer_manifest_rejects_invalid_payloads(payload):
+    with pytest.raises(ValueError):
+        protocol.validate_transfer_manifest(payload)
+
+
+def test_validate_source_descriptor_normalizes_github_source():
+    assert protocol.validate_source_descriptor(
+        {
+            "type": " GITHUB ",
+            "repo": "owner/repo",
+            "ref": "main",
+            "subpath": "/packs/demo/",
+        }
+    ) == {
+        "type": "github",
+        "repo": "owner/repo",
+        "ref": "main",
+        "subpath": "packs/demo",
+    }
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        None,
+        {},
+        {"type": "gitlab", "repo": "owner/repo", "ref": "main", "subpath": "p"},
+        {"type": "github", "repo": "owner", "ref": "main", "subpath": "p"},
+        {"type": "github", "repo": "owner/repo", "ref": "", "subpath": "p"},
+        {
+            "type": "github",
+            "repo": "owner/repo",
+            "ref": "main",
+            "subpath": "../secret",
+        },
+        {
+            "type": "github",
+            "repo": "owner/repo",
+            "ref": "main",
+            "subpath": "packs\\demo",
+        },
+    ],
+)
+def test_validate_source_descriptor_rejects_invalid_sources(source):
+    with pytest.raises(ValueError):
+        protocol.validate_source_descriptor(source)
+
+
+def test_validate_pack_manifest_normalizes_categories_and_source():
+    result = protocol.validate_pack_manifest(
+        valid_manifest(
+            categories={"happy": "开心", "sad": {"description": ""}},
+            source={
+                "type": "github",
+                "repo": "owner/repo",
+                "ref": "main",
+                "subpath": "packs/demo",
+            },
+        )
+    )
+    assert result["categories"] == {
+        "happy": {"description": "开心"},
+        "sad": {"description": "请添加描述"},
+    }
+    assert result["source"]["repo"] == "owner/repo"
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        None,
+        {},
+        valid_manifest(name=""),
+        valid_manifest(version=""),
+        valid_manifest(categories={}),
+        valid_manifest(categories=[]),
+        valid_manifest(categories={"": "空"}),
+        valid_manifest(categories={"../escape": "越界"}),
+    ],
+)
+def test_validate_pack_manifest_rejects_invalid_manifests(manifest):
+    with pytest.raises(ValueError):
+        protocol.validate_pack_manifest(manifest)
+
+
+def test_validate_pack_directory_reads_valid_manifest(tmp_path):
+    pack_dir = tmp_path / "pack"
+    (pack_dir / "memes").mkdir(parents=True)
+    (pack_dir / "manifest.json").write_text(
+        json.dumps(valid_manifest(), ensure_ascii=False), encoding="utf-8"
+    )
+    result = protocol.validate_pack_directory(pack_dir)
+    assert result["id"] == "test-pack"
+
+
+@pytest.mark.parametrize("missing", ["directory", "manifest", "memes", "json"])
+def test_validate_pack_directory_rejects_incomplete_packs(tmp_path, missing):
+    pack_dir = tmp_path / "pack"
+    if missing == "directory":
+        with pytest.raises(ValueError):
+            protocol.validate_pack_directory(pack_dir)
+        return
+
+    pack_dir.mkdir()
+    if missing != "memes":
+        (pack_dir / "memes").mkdir()
+    if missing != "manifest":
+        content = "not json" if missing == "json" else json.dumps(valid_manifest())
+        (pack_dir / "manifest.json").write_text(content, encoding="utf-8")
+    with pytest.raises(ValueError):
+        protocol.validate_pack_directory(pack_dir)
+
+
+def test_validate_community_index_normalizes_entries():
+    entry = {
+        "id": "community-pack",
+        "name": "社区包",
+        "maintainer": "tester",
+        "description": "description",
+        "license": "MIT",
+        "previews": ["preview.png"],
+        "source": {
+            "type": "github",
+            "repo": "owner/repo",
+            "ref": "main",
+            "subpath": "packs/community",
+        },
+    }
+    result = protocol.validate_community_index({"packs": [entry]})
+    assert result["packs"][0]["id"] == "community-pack"
+    assert result["packs"][0]["source"]["type"] == "github"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {},
+        {"packs": {}},
+        {"packs": [None]},
+        {"packs": [{"id": "missing-fields"}]},
+        {
+            "packs": [
+                {
+                    "id": "duplicate",
+                    "name": "a",
+                    "maintainer": "a",
+                    "description": "a",
+                    "license": "MIT",
+                    "previews": ["a"],
+                    "source": {
+                        "type": "github",
+                        "repo": "a/b",
+                        "ref": "main",
+                        "subpath": "a",
+                    },
+                }
+            ]
+            * 2
+        },
+    ],
+)
+def test_validate_community_index_rejects_invalid_payloads(payload):
+    with pytest.raises(ValueError):
+        protocol.validate_community_index(payload)
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        ({"id": "official-demo"}, True),
+        ({"id": "demo", "tags": ["Official"]}, True),
+        ({"id": "demo", "tags": ["community"]}, False),
+        (None, False),
+    ],
+)
+def test_is_official_pack_entry(entry, expected):
+    assert protocol.is_official_pack_entry(entry) is expected

--- a/tests/test_pack_resolver.py
+++ b/tests/test_pack_resolver.py
@@ -1,0 +1,140 @@
+import json
+
+import pytest
+from astrbot_plugin_meme_manager.backend import pack_resolver as resolver
+
+
+@pytest.fixture
+def resolver_paths(tmp_path, monkeypatch):
+    packs_dir = tmp_path / "packs"
+    packs_dir.mkdir()
+    registry_path = tmp_path / "registry.json"
+    rules_path = tmp_path / "selection_rules.json"
+    monkeypatch.setattr(resolver, "PACKS_DIR", packs_dir)
+    monkeypatch.setattr(resolver, "REGISTRY_PATH", registry_path)
+    monkeypatch.setattr(resolver, "SELECTION_RULES_PATH", rules_path)
+    monkeypatch.setattr(resolver, "DEFAULT_PACK_ID", "builtin-default")
+    monkeypatch.setattr(resolver, "LEGACY_MIGRATED_PACK_ID", "legacy-migrated")
+    monkeypatch.setattr(resolver, "DEFAULT_CATEGORY_DESCRIPTIONS", {"happy": "开心"})
+    return packs_dir, registry_path, rules_path
+
+
+def write_runtime_data(paths, packs, rules):
+    packs_dir, registry_path, rules_path = paths
+    for pack in packs:
+        (packs_dir / pack["id"]).mkdir(exist_ok=True)
+    registry_path.write_text(json.dumps({"installed_packs": packs}), encoding="utf-8")
+    rules_path.write_text(json.dumps({"rules": rules}), encoding="utf-8")
+
+
+def test_resolve_pack_id_prefers_matching_session_then_persona(resolver_paths):
+    packs = [
+        {"id": "session-pack", "enabled": True},
+        {"id": "persona-pack", "enabled": True},
+        {"id": "default-pack", "enabled": True},
+    ]
+    rules = [
+        {"scope": "default", "pack_id": "default-pack"},
+        {"scope": "session", "target": "session-1", "pack_id": "session-pack"},
+        {"scope": "persona", "target": "persona-1", "pack_id": "persona-pack"},
+    ]
+    write_runtime_data(resolver_paths, packs, rules)
+    assert resolver.resolve_pack_id("session-1", "persona-1") == "session-pack"
+    assert resolver.resolve_pack_id("other", "persona-1") == "persona-pack"
+    assert resolver.resolve_pack_id("other", "other") == "default-pack"
+
+
+def test_resolve_pack_id_skips_disabled_and_missing_rule_targets(resolver_paths):
+    packs = [
+        {"id": "disabled-pack", "enabled": False},
+        {"id": "enabled-pack", "enabled": True},
+    ]
+    rules = [
+        {"scope": "session", "target": "session-1", "pack_id": "disabled-pack"},
+        {"scope": "persona", "target": "persona-1", "pack_id": "missing-pack"},
+    ]
+    write_runtime_data(resolver_paths, packs, rules)
+    assert resolver.resolve_pack_id("session-1", "persona-1") == "enabled-pack"
+
+
+@pytest.mark.parametrize("fallback_id", ["legacy-migrated", "builtin-default"])
+def test_resolve_pack_id_allows_builtin_fallback_without_registry(
+    resolver_paths, fallback_id
+):
+    packs_dir, registry_path, rules_path = resolver_paths
+    (packs_dir / fallback_id).mkdir()
+    registry_path.write_text("{}", encoding="utf-8")
+    rules_path.write_text("{}", encoding="utf-8")
+    assert resolver.resolve_pack_id() == fallback_id
+
+
+def test_resolve_pack_id_returns_builtin_when_runtime_files_are_corrupt(
+    resolver_paths,
+):
+    _, registry_path, rules_path = resolver_paths
+    registry_path.write_text("not-json", encoding="utf-8")
+    rules_path.write_text("not-json", encoding="utf-8")
+    assert resolver.resolve_pack_id() == "builtin-default"
+
+
+def test_get_pack_paths_uses_pack_root(resolver_paths):
+    paths = resolver.get_pack_paths("demo")
+    assert paths["pack_dir"] == resolver_paths[0] / "demo"
+    assert paths["memes_dir"] == resolver_paths[0] / "demo" / "memes"
+    assert paths["metadata_path"].name == "memes_data.json"
+    assert paths["manifest_path"].name == "manifest.json"
+
+
+def test_load_pack_category_mapping_prefers_metadata(resolver_paths):
+    pack_dir = resolver_paths[0] / "demo"
+    pack_dir.mkdir()
+    (pack_dir / "memes_data.json").write_text(
+        json.dumps({"happy": "元数据", "needs_review": "隐藏"}), encoding="utf-8"
+    )
+    (pack_dir / "manifest.json").write_text(
+        json.dumps({"categories": {"sad": "清单"}}), encoding="utf-8"
+    )
+    assert resolver.load_pack_category_mapping("demo") == {"happy": "元数据"}
+
+
+def test_load_pack_category_mapping_falls_back_to_manifest(resolver_paths):
+    pack_dir = resolver_paths[0] / "demo"
+    pack_dir.mkdir()
+    (pack_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "categories": {
+                    "happy": {"description": "开心"},
+                    "sad": "伤心",
+                    "": "忽略",
+                    "../bad": "忽略",
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    assert resolver.load_pack_category_mapping("demo") == {
+        "happy": "开心",
+        "sad": "伤心",
+    }
+
+
+def test_load_pack_category_mapping_uses_builtin_defaults(resolver_paths):
+    (resolver_paths[0] / "builtin-default").mkdir()
+    assert resolver.load_pack_category_mapping("builtin-default") == {"happy": "开心"}
+    assert resolver.load_pack_category_mapping("other") == {}
+
+
+def test_resolve_pack_context_combines_paths_and_mapping(resolver_paths):
+    packs = [{"id": "demo", "enabled": True}]
+    rules = [{"scope": "default", "pack_id": "demo"}]
+    write_runtime_data(resolver_paths, packs, rules)
+    pack_dir = resolver_paths[0] / "demo"
+    (pack_dir / "memes_data.json").write_text(
+        json.dumps({"happy": "开心"}), encoding="utf-8"
+    )
+    context = resolver.resolve_pack_context()
+    assert context["pack_id"] == "demo"
+    assert context["pack_dir"] == pack_dir
+    assert context["category_mapping"] == {"happy": "开心"}

--- a/tests/test_pack_storage_helpers.py
+++ b/tests/test_pack_storage_helpers.py
@@ -1,0 +1,256 @@
+import json
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+import requests
+from astrbot_plugin_meme_manager.backend import pack_storage as storage
+
+
+@pytest.mark.parametrize(
+    ("raw", "accelerator", "expected"),
+    [
+        ("https://github.com/a", "", "https://github.com/a"),
+        (
+            "https://github.com/a",
+            "https://proxy/",
+            "https://proxy/https://github.com/a",
+        ),
+        (
+            "https://github.com/a",
+            "https://proxy/{url}",
+            "https://proxy/https://github.com/a",
+        ),
+        ("", "https://proxy", ""),
+    ],
+)
+def test_build_accelerated_url(raw, accelerator, expected):
+    assert storage._build_accelerated_url(raw, accelerator) == expected
+
+
+def test_http_get_uses_accelerator_and_falls_back(monkeypatch):
+    class Response:
+        def __init__(self, status_code):
+            self.status_code = status_code
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    accelerated = Response(500)
+    native = Response(200)
+    responses = iter([accelerated, native])
+    calls = []
+
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        return next(responses)
+
+    monkeypatch.setattr(storage.requests, "get", get)
+    result = storage._http_get_with_optional_acceleration(
+        "https://github.com/a", 10, "https://proxy", stream=True
+    )
+    assert result is native
+    assert accelerated.closed
+    assert calls[0][0] == "https://proxy/https://github.com/a"
+    assert calls[1][0] == "https://github.com/a"
+    assert calls[1][1] == {"timeout": 10, "stream": True}
+
+
+def test_http_get_reports_both_failures(monkeypatch):
+    def get(url, **kwargs):
+        raise requests.RequestException(url)
+
+    monkeypatch.setattr(storage.requests, "get", get)
+    with pytest.raises(ValueError, match="加速与原生请求均失败"):
+        storage._http_get_with_optional_acceleration(
+            "https://github.com/a", 10, "https://proxy"
+        )
+
+
+def test_atomic_json_and_snapshot_helpers(tmp_path):
+    path = tmp_path / "state" / "data.json"
+    storage._save_json(path, {"value": "开心"})
+    original = path.read_bytes()
+    assert storage._load_json(path, {}) == {"value": "开心"}
+    storage._save_json(path, {"value": "changed"})
+    storage._restore_file_snapshot(path, original)
+    assert path.read_bytes() == original
+    storage._restore_file_snapshot(path, None)
+    assert not path.exists()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(0, 0), (" 12 ", 12), (-1, None), (True, None), ("bad", None)],
+)
+def test_safe_nonnegative_integer(value, expected):
+    assert storage._safe_nonnegative_int(value) == expected
+
+
+def test_index_bundle_details_validates_manifest_path(tmp_path):
+    root = tmp_path / "index"
+    root.mkdir()
+    index_path = root / "snapshot.faiss"
+    index_path.write_bytes(b"index")
+    (root / "index_manifest.json").write_text(
+        json.dumps({"index_file": "snapshot.faiss"}), encoding="utf-8"
+    )
+    manifest, resolved = storage._index_bundle_details(root)
+    assert manifest["index_file"] == "snapshot.faiss"
+    assert resolved == index_path
+    (root / "index_manifest.json").write_text(
+        json.dumps({"index_file": "../escape.faiss"}), encoding="utf-8"
+    )
+    assert storage._index_bundle_details(root)[1] is None
+
+
+def test_directory_size_and_free_space_guard(tmp_path, monkeypatch):
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "a.bin").write_bytes(b"123")
+    (tmp_path / "nested" / "b.bin").write_bytes(b"4567")
+    assert storage._directory_size(tmp_path) == 7
+    assert storage._directory_size(tmp_path / "missing") == 0
+    monkeypatch.setattr(
+        storage.shutil, "disk_usage", lambda path: SimpleNamespace(free=100)
+    )
+    storage._require_free_space(tmp_path / "space", 100, "测试")
+    with pytest.raises(ValueError, match="剩余磁盘空间不足"):
+        storage._require_free_space(tmp_path / "space", 101, "测试")
+
+
+def test_legacy_pack_and_installed_pack_helpers():
+    assert storage._is_legacy_pack(storage.LEGACY_MIGRATED_PACK_ID, {})
+    assert storage._is_legacy_pack("custom", {"tags": ["Converted"]})
+    assert not storage._is_legacy_pack("custom", {"tags": ["normal"]})
+    assert storage._normalize_installed_packs([{"id": "a"}, None, "bad"]) == [
+        {"id": "a"}
+    ]
+    assert storage._normalize_installed_packs({}) == []
+
+
+def test_count_images_only_counts_supported_files_in_categories(tmp_path):
+    memes = tmp_path / "memes"
+    category = memes / "happy"
+    category.mkdir(parents=True)
+    (category / "one.PNG").write_bytes(b"1")
+    (category / "ignore.txt").write_bytes(b"2")
+    (memes / "root.png").write_bytes(b"3")
+    assert storage._count_images(memes) == 1
+    assert storage._count_images(tmp_path / "missing") == 0
+
+
+def test_archive_root_and_manifest_detection(tmp_path):
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "manifest.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "__MACOSX").mkdir()
+    assert storage._find_manifest_root(tmp_path) == nested
+    (tmp_path / "manifest.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="多个 manifest"):
+        storage._find_manifest_root(tmp_path)
+
+
+def test_find_import_root_detects_v1_v2_and_legacy(tmp_path):
+    v1 = tmp_path / "v1"
+    v1.mkdir()
+    (v1 / "manifest.json").write_text("{}", encoding="utf-8")
+    assert storage._find_import_root(tmp_path) == (v1, "v1")
+    (v1 / storage.PACK_TRANSFER_MANIFEST).write_text("{}", encoding="utf-8")
+    assert storage._find_import_root(tmp_path) == (v1, "v2")
+
+    (v1 / "manifest.json").unlink()
+    legacy_memes = v1 / "memes" / "happy"
+    legacy_memes.mkdir(parents=True)
+    (legacy_memes / "meme.png").write_bytes(b"image")
+    assert storage._find_import_root(tmp_path) == (v1, "legacy")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("My Pack", "my-pack"), ("a", "legacy-pack"), ("中文", "legacy-pack")],
+)
+def test_legacy_pack_id_normalization(value, expected):
+    assert storage._legacy_pack_id(value) == expected
+
+
+def test_copy_legacy_pack_supports_direct_category_layout(tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    category = source / "happy"
+    category.mkdir(parents=True)
+    (category / "meme.png").write_bytes(b"image")
+    (source / "memes_data.json").write_text(
+        json.dumps({"happy": "开心"}, ensure_ascii=False), encoding="utf-8"
+    )
+    manifest = storage._copy_legacy_pack(source, target, "My Pack")
+    assert manifest["id"] == "my-pack"
+    assert (target / "memes" / "happy" / "meme.png").is_file()
+    assert storage._load_json(target / "memes_data.json", {}) == {"happy": "开心"}
+
+
+def make_zip(path, files):
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+
+
+def test_extract_zip_safely_extracts_regular_archive(tmp_path, monkeypatch):
+    archive_path = tmp_path / "pack.zip"
+    make_zip(archive_path, {"pack/manifest.json": "{}", "pack/memes/a.png": b"image"})
+    monkeypatch.setattr(storage, "_require_free_space", lambda *args: None)
+    target = tmp_path / "extract"
+    storage._extract_zip_safely(archive_path, target)
+    assert (target / "pack" / "memes" / "a.png").is_file()
+
+
+@pytest.mark.parametrize("member", ["../escape.txt", "pack/script.sh"])
+def test_extract_zip_safely_rejects_traversal_and_scripts(
+    tmp_path, monkeypatch, member
+):
+    archive_path = tmp_path / "bad.zip"
+    make_zip(archive_path, {member: "bad"})
+    monkeypatch.setattr(storage, "_require_free_space", lambda *args: None)
+    with pytest.raises(ValueError):
+        storage._extract_zip_safely(archive_path, tmp_path / "extract")
+
+
+def test_load_transfer_info_defaults_for_legacy_format(tmp_path):
+    pack = tmp_path / "pack"
+    pack.mkdir()
+    assert storage._load_transfer_info(pack, "v1") == {
+        "format": storage.PACK_TRANSFER_FORMAT,
+        "format_version": 1,
+        "export_mode": "share",
+        "features": {"semantic_metadata": False, "vectors": False},
+    }
+
+
+def test_validate_and_normalize_selection_rules():
+    rules = [
+        {"id": "session", "scope": "SESSION", "target": "s1", "pack_id": "a"},
+        {"id": "default", "scope": "default", "pack_id": "b"},
+    ]
+    assert storage._validate_and_normalize_rules(rules, {"a", "b"}) == [
+        {"id": "session", "scope": "session", "pack_id": "a", "target": "s1"},
+        {"id": "default", "scope": "default", "pack_id": "b"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "rules",
+    [
+        [],
+        [None],
+        [{"id": "x", "scope": "bad", "pack_id": "a"}],
+        [{"id": "x", "scope": "session", "pack_id": "a"}],
+        [{"id": "default", "scope": "default", "pack_id": "missing"}],
+        [
+            {"id": "default", "scope": "default", "pack_id": "a"},
+            {"id": "session", "scope": "session", "target": "s", "pack_id": "a"},
+        ],
+    ],
+)
+def test_validate_and_normalize_selection_rules_rejects_invalid_rules(rules):
+    with pytest.raises(ValueError):
+        storage._validate_and_normalize_rules(rules, {"a"})

--- a/tests/test_provider_helpers.py
+++ b/tests/test_provider_helpers.py
@@ -1,0 +1,200 @@
+import json
+from pathlib import Path
+
+import pytest
+import requests
+from image_host.providers.cloudflare_r2_provider import CloudflareR2Provider
+from image_host.providers.stardots_provider import StarDotsProvider
+from image_host.providers.webdav_provider import (
+    AuthenticationError,
+    InvalidResponseError,
+    NetworkError,
+    WebDAVProvider,
+)
+
+
+def test_r2_key_category_parsing_and_public_urls(tmp_path):
+    provider = object.__new__(CloudflareR2Provider)
+    provider.public_url = "https://cdn.example/"
+    provider.bucket_name = "bucket"
+    provider.account_id = "account"
+
+    file_path = tmp_path / "happy" / "meme.png"
+    file_path.parent.mkdir()
+    assert provider._get_category_from_path(file_path) == "happy"
+    assert provider._generate_s3_key(file_path) == "memes/happy/meme.png"
+    assert provider._parse_s3_key("memes/happy/meme.png") == ("happy", "meme.png")
+    assert provider._parse_s3_key("memes/meme.png") == ("", "meme.png")
+    assert provider._get_public_url("memes/happy/meme.png") == (
+        "https://cdn.example/memes/happy/meme.png"
+    )
+    provider.public_url = ""
+    assert provider._get_public_url("memes/meme.png") == (
+        "https://bucket.account.r2.dev/memes/meme.png"
+    )
+
+
+def test_stardots_category_size_rate_limit_and_cache_helpers():
+    provider = object.__new__(StarDotsProvider)
+    assert provider._encode_category("") == ""
+    assert provider._encode_category("animals/cats") == "animals@@DIR@@cats"
+    assert provider._decode_category("animals@@DIR@@cats") == "animals/cats"
+    assert provider._decode_category("") == provider.DEFAULT_CATEGORY
+    assert provider._extract_image_size({"fileSize": "42"}) == 42
+    assert provider._extract_image_size({"bytes": 12.8}) == 12
+    assert provider._extract_image_size({"size": "unknown"}) is None
+    assert provider._is_rate_limit_error("Too Many Requests")
+    assert provider._is_rate_limit_error("请求频率已超限")
+    assert not provider._is_rate_limit_error("invalid timestamp")
+    provider._image_list_cache = {"images": []}
+    provider._invalidate_image_list_cache()
+    assert provider._image_list_cache is None
+
+
+def test_stardots_upload_records_load_save_and_corruption(tmp_path):
+    provider = object.__new__(StarDotsProvider)
+    provider.records_file = tmp_path / "records.json"
+    provider._upload_records = {"meme.png": {"category": "happy"}}
+    provider._save_records()
+    assert json.loads(provider.records_file.read_text(encoding="utf-8")) == {
+        "meme.png": {"category": "happy"}
+    }
+    provider._upload_records = {}
+    provider._load_records()
+    assert provider._upload_records == {"meme.png": {"category": "happy"}}
+    provider.records_file.write_text("not-json", encoding="utf-8")
+    provider._load_records()
+    assert provider._upload_records == {}
+
+
+@pytest.fixture
+def webdav(tmp_path):
+    provider = object.__new__(WebDAVProvider)
+    provider.base_url = "https://dav.example/root"
+    provider.public_url = "https://public.example"
+    provider.base_path = "memes"
+    provider.local_dir = tmp_path
+    provider.timeout = 10
+    provider.verify_ssl = True
+    return provider
+
+
+def test_webdav_path_and_url_helpers(webdav, tmp_path):
+    assert webdav._normalize_path("/a\\b/") == "a/b"
+    assert webdav._normalize_path(None) == ""
+    assert webdav._url_for_path("") == "https://dav.example/root"
+    assert webdav._url_for_path("memes/中文 图.png") == (
+        "https://dav.example/root/memes/%E4%B8%AD%E6%96%87%20%E5%9B%BE.png"
+    )
+    assert webdav._remote_id_to_path("happy/meme.png") == "memes/happy/meme.png"
+    assert webdav._strip_base_path("memes/happy/meme.png") == "happy/meme.png"
+    assert webdav._strip_base_path("memes") == ""
+    assert webdav._public_url_for_id("happy/中文.png").endswith(
+        "happy/%E4%B8%AD%E6%96%87.png"
+    )
+    local_file = tmp_path / "happy" / "meme.png"
+    assert webdav._get_remote_id(local_file) == "happy/meme.png"
+    assert webdav._get_remote_id(Path("C:/outside/meme.png")) == "meme.png"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        ("false", False),
+        ("否", False),
+        ("yes", True),
+        (0, False),
+    ],
+)
+def test_webdav_boolean_parser(webdav, value, expected):
+    assert webdav._parse_bool(value) is expected
+
+
+def test_webdav_parse_propfind_response(webdav):
+    xml = """<?xml version="1.0"?>
+    <D:multistatus xmlns:D="DAV:">
+      <D:response>
+        <D:href>/root/memes/happy/</D:href>
+        <D:propstat><D:prop><D:resourcetype><D:collection/></D:resourcetype></D:prop></D:propstat>
+      </D:response>
+      <D:response>
+        <D:href>/root/memes/happy/meme.png</D:href>
+        <D:propstat><D:prop><D:resourcetype/><D:getcontentlength>123</D:getcontentlength></D:prop></D:propstat>
+      </D:response>
+    </D:multistatus>"""
+    entries = webdav._parse_propfind_response(xml, "memes/happy")
+    assert entries == [
+        {"path": "memes/happy", "is_dir": True, "size": 0},
+        {"path": "memes/happy/meme.png", "is_dir": False, "size": 123},
+    ]
+    with pytest.raises(InvalidResponseError):
+        webdav._parse_propfind_response("not xml", "memes")
+
+
+def test_webdav_ensure_remote_directories_accepts_created_and_existing(webdav):
+    statuses = iter([201, 405])
+    calls = []
+
+    class Response:
+        def __init__(self, status_code):
+            self.status_code = status_code
+
+    def request(method, url):
+        calls.append((method, url))
+        return Response(next(statuses))
+
+    webdav._request = request
+    webdav._ensure_remote_dirs("memes/happy")
+    assert calls == [
+        ("MKCOL", "https://dav.example/root/memes"),
+        ("MKCOL", "https://dav.example/root/memes/happy"),
+    ]
+
+
+def test_webdav_ensure_remote_directories_rejects_failure(webdav):
+    class Response:
+        status_code = 500
+
+    webdav._request = lambda method, url: Response()
+    with pytest.raises(InvalidResponseError):
+        webdav._ensure_remote_dirs("memes")
+
+
+def test_webdav_request_adds_defaults_and_maps_errors(webdav):
+    class Response:
+        status_code = 200
+
+    class Session:
+        def __init__(self):
+            self.kwargs = None
+
+        def request(self, method, url, **kwargs):
+            self.kwargs = kwargs
+            return Response()
+
+    session = Session()
+    webdav.session = session
+    assert webdav._request("GET", "https://dav.example") is not None
+    assert session.kwargs == {"timeout": 10, "verify": True}
+
+    class AuthSession:
+        @staticmethod
+        def request(method, url, **kwargs):
+            response = Response()
+            response.status_code = 401
+            return response
+
+    webdav.session = AuthSession()
+    with pytest.raises(AuthenticationError):
+        webdav._request("GET", "https://dav.example")
+
+    class FailedSession:
+        @staticmethod
+        def request(method, url, **kwargs):
+            raise requests.RequestException("offline")
+
+    webdav.session = FailedSession()
+    with pytest.raises(NetworkError):
+        webdav._request("GET", "https://dav.example")

--- a/tests/test_semantic_caption.py
+++ b/tests/test_semantic_caption.py
@@ -1,0 +1,183 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from backend import semantic_caption as caption
+from PIL import Image
+
+
+def test_build_caption_tool_set_contains_required_schema():
+    tool_set = caption._build_caption_tool_set(["happy", "sad"])
+    tools = getattr(tool_set, "tools", [])
+    assert len(tools) == 1
+    tool = tools[0]
+    assert tool.name == caption.CAPTION_TOOL_NAME
+    assert tool.parameters["properties"]["suggested_category"]["enum"] == [
+        "",
+        "happy",
+        "sad",
+    ]
+
+
+def test_build_caption_prompt_contains_category_catalog_frames_and_review():
+    prompt = caption.build_caption_prompt(
+        frame_count=3,
+        category="happy",
+        category_description="开心回应",
+        available_categories={"happy": "开心回应", "sad": "伤心"},
+        review_instruction="这是自嘲，不是嘲笑别人",
+        current_semantic={
+            "caption": "旧描述",
+            "tags": ["旧标签"],
+            "current_category": "happy",
+            "original_category": "sad",
+        },
+    )
+    assert '当前分类名称："happy"' in prompt
+    assert '"sad": "伤心"' in prompt
+    assert '"happy": "开心回应"' not in prompt
+    assert "人工复审纠错" in prompt
+    assert "这是自嘲，不是嘲笑别人" in prompt
+    assert "3 张图片来自同一个 GIF" in prompt
+
+
+def test_prepare_visual_inputs_keeps_static_image(tmp_path):
+    image_path = tmp_path / "static.png"
+    Image.new("RGB", (2, 2), "red").save(image_path)
+    visual_paths, temp_paths = caption.prepare_visual_inputs(image_path)
+    assert visual_paths == [str(image_path.resolve())]
+    assert temp_paths == []
+
+
+def test_prepare_visual_inputs_samples_animated_gif_and_legacy_wrapper(tmp_path):
+    gif_path = tmp_path / "animated.gif"
+    frames = [Image.new("RGB", (2, 2), color) for color in ("red", "green", "blue")]
+    frames[0].save(
+        gif_path,
+        save_all=True,
+        append_images=frames[1:],
+        duration=50,
+        loop=0,
+    )
+    visual_paths, temp_paths = caption.prepare_visual_inputs(gif_path)
+    try:
+        assert len(visual_paths) == 3
+        assert visual_paths == temp_paths
+        assert all(Path(path).is_file() for path in temp_paths)
+    finally:
+        for path in temp_paths:
+            Path(path).unlink(missing_ok=True)
+
+    first_path, temporary_path = caption.prepare_visual_input(gif_path)
+    try:
+        assert first_path == temporary_path
+        assert Path(first_path).is_file()
+    finally:
+        Path(first_path).unlink(missing_ok=True)
+
+
+def test_prepare_visual_inputs_handles_unknown_static_and_broken_animation(tmp_path):
+    unknown = tmp_path / "image.bin"
+    unknown.write_bytes(b"not-an-image")
+    assert caption.prepare_visual_inputs(unknown) == ([str(unknown.resolve())], [])
+    broken_gif = tmp_path / "broken.gif"
+    broken_gif.write_bytes(b"not-a-gif")
+    with pytest.raises(ValueError, match="动图多帧处理失败"):
+        caption.prepare_visual_inputs(broken_gif)
+
+
+@pytest.mark.parametrize(
+    ("usage", "names", "expected"),
+    [
+        ({"input_tokens": "12"}, ("input_tokens",), 12),
+        (SimpleNamespace(prompt_tokens=8), ("prompt_tokens",), 8),
+        ({"value": -1}, ("value",), 0),
+        ({"value": "bad"}, ("value",), 0),
+        (None, ("value",), 0),
+    ],
+)
+def test_read_usage_number(usage, names, expected):
+    assert caption._read_usage_number(usage, *names) == expected
+
+
+def test_extract_token_usage_supports_new_old_and_nested_shapes():
+    assert caption.extract_token_usage(
+        {"usage": {"input": 10, "output": 5, "total": 15}}
+    ) == {"input": 10, "output": 5, "total": 15, "calls": 1}
+    assert caption.extract_token_usage(
+        SimpleNamespace(
+            usage=SimpleNamespace(
+                prompt_tokens=10, cached_tokens=2, completion_tokens=3
+            )
+        )
+    ) == {"input": 12, "output": 3, "total": 15, "calls": 1}
+    assert caption.extract_token_usage(
+        SimpleNamespace(
+            usage=None,
+            raw_completion=SimpleNamespace(
+                usage=SimpleNamespace(input_tokens=4, output_tokens=2)
+            ),
+        )
+    ) == {"input": 4, "output": 2, "total": 6, "calls": 1}
+
+
+def test_merge_token_usage_ignores_invalid_and_negative_values():
+    assert caption._merge_token_usage(
+        [
+            {"input": 3, "output": 2, "total": 5, "calls": 1},
+            {"input": -1, "output": "bad", "total": 4, "calls": 1},
+        ]
+    ) == {"input": 3, "output": 2, "total": 9, "calls": 2}
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("response_format is unsupported", True),
+        ("结构化输出不支持", True),
+        ("network unavailable", False),
+    ],
+)
+def test_structured_output_unsupported_detection(message, expected):
+    assert caption._structured_output_is_unsupported(RuntimeError(message)) is expected
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("tool_choice is unsupported", True),
+        ("工具调用未启用", True),
+        ("request timed out", False),
+        ("tools request timed out", False),
+    ],
+)
+def test_tool_call_unsupported_detection(message, expected):
+    assert caption._tool_call_is_unsupported(RuntimeError(message)) is expected
+
+
+def test_caption_output_mode_cache():
+    context = SimpleNamespace()
+    assert caption._caption_output_mode(context, "provider") == ""
+    caption._remember_caption_output_mode(context, "provider", "tool")
+    assert caption._caption_output_mode(context, "provider") == "tool"
+
+
+def test_caption_tool_and_response_payloads():
+    response = {
+        "tools_call_name": ["other", caption.CAPTION_TOOL_NAME],
+        "tools_call_args": [{"ignored": True}, {"caption": "猫"}],
+        "completion_text": "fallback",
+    }
+    assert caption._caption_tool_call_payload(response) == (
+        True,
+        {"caption": "猫"},
+    )
+    assert caption._caption_response_payload(response) == {"caption": "猫"}
+    assert caption._caption_tool_call_payload({"tools_call_name": "other"}) == (
+        False,
+        None,
+    )
+    assert caption._caption_response_payload({"completion_text": "text"}) == "text"
+    assert caption._caption_response_payload(SimpleNamespace(text="object text")) == (
+        "object text"
+    )

--- a/tests/test_semantic_index.py
+++ b/tests/test_semantic_index.py
@@ -1,0 +1,223 @@
+from types import SimpleNamespace
+
+import pytest
+from backend import semantic_index as index
+from backend.semantic_models import SemanticImage
+
+
+class SyncEmbeddingProvider:
+    provider_config = {"id": "provider-id", "embedding_model": "model-name"}
+
+    @staticmethod
+    def get_dim():
+        return 2
+
+    def __init__(self):
+        self.calls = []
+
+    def get_embedding(self, text):
+        self.calls.append(text)
+        return [3, 4]
+
+
+class AsyncEmbeddingProvider(SyncEmbeddingProvider):
+    async def get_embedding(self, text):
+        self.calls.append(text)
+        return [0, 2]
+
+    async def get_embeddings(self, texts):
+        return [[1, 0] for _ in texts]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(0, 0), ("12", 12), (" 3 ", 3), (-1, None), (True, None), ("bad", None)],
+)
+def test_manifest_integer_parser(value, expected):
+    assert index._manifest_int(value) == expected
+
+
+def test_embedding_adapter_reads_metadata_and_readiness():
+    provider = SyncEmbeddingProvider()
+    adapter = index.EmbeddingAdapter(provider)
+    assert adapter.provider_id == "provider-id"
+    assert adapter.model_name == "model-name"
+    assert adapter.dimension == 2
+    assert adapter.ready
+    assert adapter.signature == "provider-id:model-name:2"
+
+
+def test_embedding_adapter_supports_meta_and_model_attributes():
+    class Provider:
+        model_name = "attribute-model"
+
+        @staticmethod
+        def meta():
+            return SimpleNamespace(id="meta-id")
+
+        @staticmethod
+        def get_dim():
+            return 3
+
+        @staticmethod
+        def get_embedding(text):
+            return [1, 0, 0]
+
+    adapter = index.EmbeddingAdapter(Provider())
+    assert adapter.signature == "meta-id:attribute-model:3"
+
+
+@pytest.mark.asyncio
+async def test_embedding_adapter_normalizes_and_caches_queries():
+    index._QUERY_VECTOR_CACHE.clear()
+    provider = SyncEmbeddingProvider()
+    adapter = index.EmbeddingAdapter(provider)
+    assert await adapter.embed(" text ") == pytest.approx([0.6, 0.8])
+    assert await adapter.embed("text") == pytest.approx([0.6, 0.8])
+    assert provider.calls == ["text"]
+
+
+@pytest.mark.asyncio
+async def test_embedding_adapter_supports_async_batch_and_fallback():
+    async_provider = AsyncEmbeddingProvider()
+    async_adapter = index.EmbeddingAdapter(async_provider)
+    assert await async_adapter.embed("text", use_cache=False) == [0, 1]
+    assert await async_adapter.embed_many(["a", "b"]) == [[1, 0], [1, 0]]
+
+    sync_provider = SyncEmbeddingProvider()
+    sync_adapter = index.EmbeddingAdapter(sync_provider)
+    assert await sync_adapter.embed_many(["a", "b"]) == [
+        pytest.approx([0.6, 0.8]),
+        pytest.approx([0.6, 0.8]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_embedding_adapter_rejects_missing_or_invalid_provider_results():
+    with pytest.raises(RuntimeError):
+        await index.EmbeddingAdapter(None).embed("text")
+
+    provider = SyncEmbeddingProvider()
+    provider.get_embedding = lambda text: [1, 2, 3]
+    with pytest.raises(RuntimeError, match="维度不一致"):
+        await index.EmbeddingAdapter(provider).embed("text", use_cache=False)
+
+    provider.get_embeddings = lambda texts: "invalid"
+    with pytest.raises(RuntimeError, match="格式无效"):
+        await index.EmbeddingAdapter(provider).embed_many(["text"])
+
+
+def test_index_paths_validate_pack_id_and_manifest_loading(tmp_path):
+    assert index.index_dir(tmp_path, "pack-id") == (
+        tmp_path.resolve() / "semantic_indexes" / "pack-id"
+    )
+    with pytest.raises(ValueError):
+        index.index_dir(tmp_path, "../bad")
+    assert index.load_index_manifest(tmp_path, "pack-id") == {}
+    manifest_path = index.index_manifest_path(tmp_path, "pack-id")
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text('{"item_count": 1}', encoding="utf-8")
+    assert index.load_index_manifest(tmp_path, "pack-id") == {"item_count": 1}
+    manifest_path.write_text("not-json", encoding="utf-8")
+    assert index.load_index_manifest(tmp_path, "pack-id") == {}
+
+
+def test_index_file_accepts_only_generated_snapshot_names(tmp_path):
+    valid = "index-" + "a" * 32 + ".faiss"
+    assert index._index_file(tmp_path, "pack-id", {"index_file": valid}).name == valid
+    assert (
+        index._index_file(tmp_path, "pack-id", {"index_file": "../escape.faiss"}).name
+        == "index.faiss"
+    )
+
+
+def test_manifest_writer_and_snapshot_cleanup(tmp_path):
+    index._write_manifest(tmp_path, "pack-id", {"item_count": 1})
+    assert index.load_index_manifest(tmp_path, "pack-id") == {"item_count": 1}
+    root = index.index_dir(tmp_path, "pack-id")
+    active = "index-" + "0" * 32 + ".faiss"
+    (root / active).write_bytes(b"active")
+    names = []
+    for number in range(4):
+        name = f"index-{number + 1:032x}.faiss"
+        (root / name).write_bytes(str(number).encode())
+        names.append(name)
+    index._cleanup_old_index_snapshots(tmp_path, "pack-id", active)
+    remaining = {path.name for path in root.glob("index-*.faiss")}
+    assert active in remaining
+    assert len(remaining) == 3
+
+
+def build_ready_item():
+    image = SemanticImage(
+        content_sha256="a" * 64,
+        relative_path="memes/happy/meme.png",
+        category="happy",
+        caption="猫在笑",
+        tags=["猫"],
+        caption_status="done",
+        embedding_status="done",
+    )
+    image.category_review_status = "auto_match"
+    image.category_review_context_hash = image.category_context_hash
+    image.text_hash = index.text_hash(image.vector_text)
+    return image.to_dict()
+
+
+def test_index_is_ready_validates_manifest_index_and_metadata(tmp_path, monkeypatch):
+    item = build_ready_item()
+    digest = "entry-id"
+    manifest = {
+        "index_format": index.INDEX_FORMAT,
+        "metadata_schema_version": index.SCHEMA_VERSION,
+        "item_count": 1,
+        "embedding_dimension": 2,
+        "embedding_provider_id": "provider",
+        "embedding_model": "model",
+        "items": {digest: {"faiss_id": 1, "text_hash": item["text_hash"]}},
+    }
+    monkeypatch.setattr(index, "load_index_manifest", lambda *args: manifest)
+    monkeypatch.setattr(
+        index, "_read_faiss_index", lambda *args: SimpleNamespace(ntotal=1, d=2)
+    )
+    metadata = {"images": {digest: item}}
+    assert index.index_is_ready(
+        tmp_path,
+        "pack-id",
+        metadata,
+        embedding_provider_id="provider",
+        embedding_model="model",
+        embedding_dimension=2,
+    )
+    assert not index.index_is_ready(
+        tmp_path, "pack-id", metadata, embedding_provider_id="other"
+    )
+    manifest["item_count"] = 0
+    assert not index.index_is_ready(tmp_path, "pack-id", metadata)
+
+
+def test_reconstruct_reusable_vectors_matches_digest_or_text_hash():
+    class Vector:
+        def __init__(self, values):
+            self.values = values
+
+        def tolist(self):
+            return self.values
+
+    class OldIndex:
+        @staticmethod
+        def reconstruct(faiss_id):
+            return Vector([3, 4])
+
+    manifest = {
+        "index_format": index.INDEX_FORMAT,
+        "metadata_schema_version": index.SCHEMA_VERSION,
+        "items": {
+            "old": {"faiss_id": 1, "text_hash": "same"},
+        },
+    }
+    vectors = index._reconstruct_reusable_vectors(
+        OldIndex(), manifest, [("new", {"text_hash": "same"})]
+    )
+    assert vectors["new"] == pytest.approx([0.6, 0.8])
+    assert index._reconstruct_reusable_vectors(None, manifest, []) == {}

--- a/tests/test_semantic_models.py
+++ b/tests/test_semantic_models.py
@@ -1,0 +1,297 @@
+import math
+
+import pytest
+from backend import semantic_models as models
+
+VALID_HASH = "a" * 64
+
+
+def test_normalize_tags_accepts_string_and_removes_duplicates():
+    assert models.normalize_tags(" happy ") == ["happy"]
+    assert models.normalize_tags(["happy", "", None, "happy", 3]) == ["happy", "3"]
+    assert models.normalize_tags({"one", "two"}) in (["one", "two"], ["two", "one"])
+    assert models.normalize_tags(123) == []
+
+
+def test_category_tag_helpers_replace_existing_category_tags():
+    assert models.build_category_tag(" happy ") == "category:happy"
+    assert models.build_category_tag("") == ""
+    assert models.is_category_tag("分类:开心")
+    assert models.is_category_tag(" category:happy ")
+    assert not models.is_category_tag("happy")
+    assert models.ensure_category_tag(
+        ["category:old", "funny", "分类:旧", "funny"], "happy"
+    ) == ["category:happy", "funny"]
+    assert models.ensure_category_tag(["funny"], "") == ["funny"]
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("auto_match", True),
+        ("needs_review", True),
+        ("manual_confirmed", True),
+        ("manual_rejected", True),
+        ("unchecked", False),
+        (None, False),
+    ],
+)
+def test_category_review_completion(status, expected):
+    assert models.category_review_is_complete(status) is expected
+
+
+def test_category_analysis_currentness():
+    assert not models.category_analysis_is_current(None)
+    assert not models.category_analysis_is_current(
+        {"category_review_status": "unchecked"}
+    )
+    assert models.category_analysis_is_current(
+        {"category_review_status": "manual_confirmed", "manual_override": True}
+    )
+    assert models.category_analysis_is_current(
+        {"category_review_status": "auto_match", "provenance": "manual"}
+    )
+    assert models.category_analysis_is_current(
+        {
+            "category_review_status": "auto_match",
+            "prompt_version": models.PROMPT_VERSION,
+        }
+    )
+    assert not models.category_analysis_is_current(
+        {"category_review_status": "auto_match", "prompt_version": "old"}
+    )
+
+
+def test_semantic_entry_id_is_stable_and_path_sensitive():
+    first = models.semantic_entry_id(VALID_HASH, "happy", "happy/a.png")
+    assert first == models.semantic_entry_id(
+        VALID_HASH.upper(), "happy", "happy\\a.png"
+    )
+    assert first != models.semantic_entry_id(VALID_HASH, "happy", "happy/b.png")
+    with pytest.raises(ValueError):
+        models.semantic_entry_id("short", "happy")
+
+
+def test_category_context_hash_normalizes_description_whitespace():
+    first = models.category_context_hash(VALID_HASH, "happy", " 开心   快乐 ")
+    second = models.category_context_hash(VALID_HASH, "happy", "开心 快乐")
+    assert first == second
+    assert first != models.category_context_hash(VALID_HASH, "sad", "开心 快乐")
+
+
+def test_anchor_caption_to_category_only_for_non_conflicting_content():
+    anchored = models.anchor_caption_to_category(
+        "角色正在大笑", ["funny"], "happy", "match", "开心 用于回应"
+    )
+    assert anchored.startswith("以当前分类“happy”（开心 用于回应）")
+    assert (
+        models.anchor_caption_to_category("角色正在大笑", [], "happy", "conflict")
+        == "角色正在大笑"
+    )
+    assert models.anchor_caption_to_category("", [], "happy", "match") == ""
+    assert models.anchor_caption_to_category(anchored, [], "happy", "match") == anchored
+
+
+def test_build_semantic_text_contains_category_once_and_content_tags():
+    text = models.build_semantic_text(
+        "猫在笑",
+        ["category:old", "可爱", "可爱"],
+        "哈哈",
+        "happy",
+        "表示开心",
+    )
+    assert "图片含义：猫在笑" in text
+    assert "固定分类标签：category:happy" in text
+    assert "分类含义：表示开心" in text
+    assert "语义标签：可爱" in text
+    assert text.count("category:happy") == 1
+
+
+def test_text_hash_is_deterministic():
+    assert models.text_hash("hello") == models.text_hash("hello")
+    assert models.text_hash("hello") != models.text_hash("world")
+
+
+def test_vector_normalization_and_cosine_similarity():
+    vector = models.normalize_vector([3, 4])
+    assert vector == pytest.approx([0.6, 0.8])
+    assert math.sqrt(sum(value * value for value in vector)) == pytest.approx(1)
+    assert models.cosine_similarity(vector, vector) == pytest.approx(1)
+    assert models.cosine_similarity([1, 0], [0, 1]) == 0
+
+
+@pytest.mark.parametrize("vector", [None, [], [0, 0], [float("nan")], [float("inf")]])
+def test_vector_normalization_rejects_invalid_vectors(vector):
+    with pytest.raises(ValueError):
+        models.normalize_vector(vector)
+
+
+def test_cosine_similarity_rejects_dimension_mismatch():
+    with pytest.raises(ValueError):
+        models.cosine_similarity([1], [1, 2])
+
+
+def test_short_id_expands_after_prefix_collision():
+    digest = "123456789abc" + "d" * 52
+    assert models.short_id(digest) == "meme:123456789abc"
+    assert models.short_id(digest, ["123456789abc"]) == "meme:123456789abcdddd"
+    with pytest.raises(ValueError):
+        models.short_id("short")
+
+
+def test_build_id_map_uses_unique_prefixes():
+    first = "123456789abc" + "0" * 52
+    second = "123456789abc" + "1" * 52
+    result = models.build_id_map([first, second, first])
+    assert result[first] == "meme:" + first[:16]
+    assert result[second] == "meme:" + second[:16]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("meme:123456789abc", "123456789abc"),
+        (" meme:ABCDEF123456 ", "abcdef123456"),
+        ("123456789abc", ""),
+        ("meme:short", ""),
+        ("meme:123456789abz", ""),
+    ],
+)
+def test_parse_meme_id(value, expected):
+    assert models.parse_meme_id(value) == expected
+
+
+def test_extract_semantic_references_deduplicates_and_cleans_markers():
+    text = (
+        "正常回复\n"
+        "&&meme:123456789abc&&\n"
+        "meme:abcdef123456 候选图片说明。后续正文\n"
+        "再次 meme:123456789abc"
+    )
+    cleaned, references = models.extract_and_clean_semantic_meme_references(text)
+    assert references == ["meme:123456789abc", "meme:abcdef123456"]
+    assert "meme:" not in cleaned
+    assert "正常回复" in cleaned
+
+
+def test_extract_visible_reply_removes_reasoning_and_machine_markers():
+    text = "<think>内部推理</think>\n```json\n可见回复 &&happy&&\n```"
+    assert models.extract_visible_semantic_reply(text) == "可见回复"
+
+
+def test_compact_semantic_query_cleans_prefix_quotes_and_limits_length():
+    assert models.compact_semantic_query('检索词： "开心   大笑。"') == "开心 大笑"
+    assert len(models.compact_semantic_query("x" * 100, max_chars=10)) == 10
+    assert len(models.compact_semantic_query("x" * 100, max_chars=1)) == 8
+
+
+@pytest.mark.parametrize(
+    ("value", "fallback", "expected"),
+    [
+        ('{"query":"开心 大笑"}', "备用", "开心 大笑"),
+        ('前文 {"keywords":"猫猫"} 后文', "备用", "猫猫"),
+        ("直接检索词", "备用", "直接检索词"),
+        ("{}", "备用词", "备用词"),
+        ("{bad json", "备用词", "备用词"),
+    ],
+)
+def test_parse_semantic_query_result(value, fallback, expected):
+    assert models.parse_semantic_query_result(value, fallback) == expected
+
+
+def test_semantic_image_normalizes_fields_and_round_trips():
+    image = models.SemanticImage(
+        content_sha256=VALID_HASH.upper(),
+        relative_path="happy\\meme.png",
+        category=" happy ",
+        category_description=" 开心 ",
+        caption="猫在笑",
+        tags=["category:old", "可爱", "可爱"],
+        caption_status="invalid",
+        embedding_status="invalid",
+        category_fit="invalid",
+        reclassification_history=[{"reason": "x" * 600}] * 25,
+    )
+    assert image.content_sha256 == VALID_HASH
+    assert image.relative_path == "happy/meme.png"
+    assert image.category == "happy"
+    assert image.tags == ["category:happy", "可爱"]
+    assert image.caption_status == "pending"
+    assert image.embedding_status == "pending"
+    assert image.category_fit == "uncertain"
+    assert len(image.reclassification_history) == 20
+    assert len(image.reclassification_history[0]["reason"]) == 500
+    assert image.text_hash == models.text_hash(image.vector_text)
+    assert models.SemanticImage.from_dict(image.to_dict()).to_dict() == image.to_dict()
+
+
+def test_semantic_image_manual_override_uses_manual_fields():
+    image = models.SemanticImage(
+        content_sha256=VALID_HASH,
+        relative_path="happy/meme.png",
+        category="happy",
+        caption="自动描述",
+        tags=["自动"],
+        visible_text="自动文字",
+        manual_caption="人工描述",
+        manual_tags=["人工", "人工"],
+        manual_visible_text="人工文字",
+        manual_override=True,
+    )
+    assert image.caption == "人工描述"
+    assert image.tags == ["category:happy", "人工"]
+    assert image.visible_text == "人工文字"
+
+
+def test_parse_caption_result_supports_json_and_embedded_json():
+    expected = ("猫在笑", ["可爱", "开心"], "哈哈")
+    assert (
+        models.parse_caption_result(
+            {"caption": "猫在笑", "tags": ["可爱", "开心"], "visible_text": "哈哈"}
+        )
+        == expected
+    )
+    assert (
+        models.parse_caption_result(
+            '工具参数 {"foo":1} 最终 {"caption":"猫在笑","tags":["可爱","开心"],"visible_text":"哈哈"}'
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("value", [None, "not json", {}, {"caption": "x", "tags": []}])
+def test_parse_caption_result_rejects_invalid_payloads(value):
+    with pytest.raises(ValueError):
+        models.parse_caption_result(value)
+
+
+def test_parse_caption_result_with_review_normalizes_review_fields():
+    result = models.parse_caption_result_with_review(
+        {
+            "caption": "猫在生气",
+            "tags": ["猫", "生气"],
+            "visible_text": "哼",
+            "category_fit": "conflict",
+            "category_review_reason": "  分类   不匹配  ",
+            "suggested_category": " angry ",
+        }
+    )
+    assert result == (
+        "猫在生气",
+        ["猫", "生气"],
+        "哼",
+        "conflict",
+        "分类 不匹配",
+        "angry",
+    )
+
+
+def test_parse_caption_result_with_review_handles_legacy_and_invalid_fit():
+    legacy = models.parse_caption_result_with_review(
+        {"caption": "猫", "tags": ["可爱"], "visible_text": ""}
+    )
+    assert legacy[3:] == ("uncertain", "模型未返回分类符合判断", "")
+    with pytest.raises(ValueError):
+        models.parse_caption_result_with_review(
+            {"caption": "猫", "tags": ["可爱"], "category_fit": "invalid"}
+        )

--- a/tests/test_semantic_query.py
+++ b/tests/test_semantic_query.py
@@ -1,0 +1,231 @@
+import hashlib
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from backend import semantic_query as query
+
+ENTRY_ID = "123456789abc" + "0" * 52
+CONTENT_HASH = hashlib.sha256(b"image").hexdigest()
+
+
+class FakeEvent:
+    def __init__(self):
+        self.extra = {}
+
+    def get_extra(self, key):
+        return self.extra.get(key)
+
+    def set_extra(self, key, value):
+        self.extra[key] = value
+
+
+@pytest.mark.asyncio
+async def test_search_memes_returns_early_for_empty_query(monkeypatch):
+    search_index = AsyncMock()
+    monkeypatch.setattr(query, "search_index", search_index)
+    result = await query.search_memes("pack", "data", "pack-id", " ", object())
+    assert result == {"ok": True, "candidates": [], "reason": "查询词不能为空"}
+    search_index.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_search_memes_requires_metadata_and_complete_index(monkeypatch):
+    monkeypatch.setattr(query, "load_metadata", lambda pack_dir: {"images": {}})
+    result = await query.search_memes("pack", "data", "pack-id", "cat", object())
+    assert result["reason"] == "资源包没有语义元数据"
+
+    monkeypatch.setattr(query, "load_metadata", lambda pack_dir: {"images": {"a": {}}})
+    monkeypatch.setattr(
+        query, "semantic_metadata_is_complete", lambda *args, **kwargs: False
+    )
+    result = await query.search_memes("pack", "data", "pack-id", "cat", object())
+    assert "尚未完成100%语义化" in result["reason"]
+
+
+@pytest.mark.asyncio
+async def test_search_memes_strips_internal_candidate_fields(monkeypatch):
+    metadata = {"images": {ENTRY_ID: {"caption": "猫"}}}
+    monkeypatch.setattr(query, "load_metadata", lambda pack_dir: metadata)
+    monkeypatch.setattr(
+        query, "semantic_metadata_is_complete", lambda *args, **kwargs: True
+    )
+    search_index = AsyncMock(
+        return_value=[
+            {
+                "id": "meme:123456789abc",
+                "content_sha256": CONTENT_HASH,
+                "entry_id": ENTRY_ID,
+                "score": 0.9,
+                "caption": "猫",
+            }
+        ]
+    )
+    monkeypatch.setattr(query, "search_index", search_index)
+
+    result = await query.search_memes(
+        "pack",
+        "data",
+        "pack-id",
+        "cat",
+        object(),
+        top_k=3,
+        min_score=0.5,
+    )
+
+    assert result == {
+        "ok": True,
+        "candidates": [{"id": "meme:123456789abc", "caption": "猫"}],
+        "max_selectable": 1,
+    }
+    assert search_index.await_args.kwargs == {"top_k": 3, "min_score": 0.5}
+
+
+@pytest.mark.asyncio
+async def test_search_memes_reports_no_matches(monkeypatch):
+    monkeypatch.setattr(query, "load_metadata", lambda pack_dir: {"images": {"a": {}}})
+    monkeypatch.setattr(
+        query, "semantic_metadata_is_complete", lambda *args, **kwargs: True
+    )
+    monkeypatch.setattr(query, "search_index", AsyncMock(return_value=[]))
+    result = await query.search_memes("pack", "data", "pack-id", "cat", object())
+    assert result["reason"] == "没有找到足够匹配的表情包"
+
+
+def test_candidate_records_adds_private_fields_for_unique_prefix(monkeypatch):
+    metadata = {
+        "images": {
+            ENTRY_ID: {
+                "content_sha256": CONTENT_HASH,
+                "caption": "猫在笑",
+                "tags": ["猫"],
+            }
+        }
+    }
+    monkeypatch.setattr(query, "load_metadata", lambda pack_dir: metadata)
+    records = query.candidate_records(
+        "pack", [{"id": "meme:123456789abc", "caption": "公开描述"}]
+    )
+    assert records[0]["entry_id"] == ENTRY_ID
+    assert records[0]["content_sha256"] == CONTENT_HASH
+    assert records[0]["caption"] == "猫在笑"
+
+
+def test_candidate_records_rejects_invalid_or_ambiguous_ids(monkeypatch):
+    metadata = {
+        "images": {
+            ENTRY_ID: {},
+            "123456789abc" + "1" * 52: {},
+        }
+    }
+    monkeypatch.setattr(query, "load_metadata", lambda pack_dir: metadata)
+    assert (
+        query.candidate_records("pack", [{"id": "bad"}, {"id": "meme:123456789abc"}])
+        == []
+    )
+
+
+def test_remember_candidates_merges_existing_event_state():
+    event = FakeEvent()
+    event.extra["meme_manager_semantic_candidates"] = {
+        "meme:oldoldoldold": {"id": "meme:oldoldoldold"}
+    }
+    query.remember_candidates(
+        event,
+        [
+            {"id": "meme:123456789abc", "caption": "猫"},
+            {"caption": "无标识"},
+        ],
+    )
+    assert set(event.extra["meme_manager_semantic_candidates"]) == {
+        "meme:oldoldoldold",
+        "meme:123456789abc",
+    }
+    query.remember_candidates(object(), [])
+
+
+def test_validate_selected_id_accepts_matching_unchanged_file(tmp_path, monkeypatch):
+    image_path = tmp_path / "memes" / "happy" / "meme.png"
+    image_path.parent.mkdir(parents=True)
+    image_path.write_bytes(b"image")
+    metadata = {
+        "images": {
+            ENTRY_ID: {
+                "relative_path": "memes/happy/meme.png",
+                "category": "happy",
+                "content_sha256": CONTENT_HASH,
+            }
+        }
+    }
+    monkeypatch.setattr(query, "load_metadata", lambda pack_dir: metadata)
+    event = FakeEvent()
+    event.extra["meme_manager_semantic_candidates"] = {
+        "meme:123456789abc": {"entry_id": ENTRY_ID}
+    }
+
+    assert (
+        query.validate_selected_id(event, "meme:123456789abc", tmp_path) == image_path
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation", ["missing-candidate", "wrong-entry", "review", "hash"]
+)
+def test_validate_selected_id_rejects_stale_or_forbidden_selection(
+    tmp_path, monkeypatch, mutation
+):
+    image_path = tmp_path / "memes" / "happy" / "meme.png"
+    image_path.parent.mkdir(parents=True)
+    image_path.write_bytes(b"image")
+    record = {
+        "relative_path": "memes/happy/meme.png",
+        "category": "happy",
+        "content_sha256": CONTENT_HASH,
+    }
+    metadata = {"images": {ENTRY_ID: record}}
+    monkeypatch.setattr(query, "load_metadata", lambda pack_dir: metadata)
+    event = FakeEvent()
+    if mutation != "missing-candidate":
+        event.extra["meme_manager_semantic_candidates"] = {
+            "meme:123456789abc": {
+                "entry_id": "abcdef123456" + "0" * 52
+                if mutation == "wrong-entry"
+                else ENTRY_ID
+            }
+        }
+    if mutation == "review":
+        record["category"] = query.REVIEW_CATEGORY
+    if mutation == "hash":
+        record["content_sha256"] = "0" * 64
+
+    assert query.validate_selected_id(event, "meme:123456789abc", tmp_path) is None
+
+
+def test_validate_selected_id_rejects_invalid_id_and_missing_file(
+    tmp_path, monkeypatch
+):
+    assert query.validate_selected_id(FakeEvent(), "invalid", tmp_path) is None
+    monkeypatch.setattr(
+        query,
+        "load_metadata",
+        lambda pack_dir: {
+            "images": {
+                ENTRY_ID: {
+                    "relative_path": "memes/missing.png",
+                    "category": "happy",
+                    "content_sha256": CONTENT_HASH,
+                }
+            }
+        },
+    )
+    event = FakeEvent()
+    event.extra["meme_manager_semantic_candidates"] = {
+        "meme:123456789abc": {"entry_id": ENTRY_ID}
+    }
+    assert query.validate_selected_id(event, "meme:123456789abc", tmp_path) is None
+
+
+def test_dumps_result_preserves_unicode():
+    dumped = query.dumps_result({"caption": "开心"})
+    assert json.loads(dumped) == {"caption": "开心"}
+    assert "开心" in dumped

--- a/tests/test_semantic_storage.py
+++ b/tests/test_semantic_storage.py
@@ -1,0 +1,254 @@
+import hashlib
+import json
+
+import pytest
+from astrbot_plugin_meme_manager.backend import semantic_storage as storage
+from astrbot_plugin_meme_manager.backend.semantic_models import SemanticImage
+
+
+def create_pack(tmp_path):
+    pack_dir = tmp_path / "pack"
+    memes_dir = pack_dir / "memes"
+    memes_dir.mkdir(parents=True)
+    return pack_dir, memes_dir
+
+
+def test_metadata_path_and_safe_relative_path(tmp_path):
+    pack_dir, _ = create_pack(tmp_path)
+    assert storage.metadata_path(pack_dir) == pack_dir / "semantic_metadata.json"
+    assert storage.safe_relative_path(pack_dir, "memes/happy.png") == (
+        pack_dir / "memes" / "happy.png"
+    )
+    assert storage.safe_relative_path(pack_dir, "../secret") is None
+    assert storage.safe_relative_path(pack_dir, str(tmp_path.resolve())) is None
+    assert storage.safe_relative_path(pack_dir, "") is None
+
+
+def test_file_sha256_reads_in_chunks(tmp_path):
+    path = tmp_path / "data.bin"
+    path.write_bytes(b"abcdef")
+    assert (
+        storage.file_sha256(path, chunk_size=2) == hashlib.sha256(b"abcdef").hexdigest()
+    )
+
+
+def test_load_category_descriptions_merges_metadata_and_manifest(tmp_path):
+    pack_dir, _ = create_pack(tmp_path)
+    (pack_dir / "memes_data.json").write_text(
+        json.dumps({"happy": "可编辑描述", "": "忽略"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    (pack_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "categories": {
+                    "happy": {"description": "清单描述"},
+                    "sad": {"description": "伤心"},
+                    "empty": {},
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    assert storage.load_category_descriptions(pack_dir) == {
+        "happy": "可编辑描述",
+        "sad": "伤心",
+        "empty": "请添加描述",
+    }
+
+
+def test_load_category_descriptions_ignores_corrupt_files(tmp_path):
+    pack_dir, _ = create_pack(tmp_path)
+    (pack_dir / "memes_data.json").write_text("not-json", encoding="utf-8")
+    (pack_dir / "manifest.json").write_text("not-json", encoding="utf-8")
+    assert storage.load_category_descriptions(pack_dir) == {}
+
+
+def test_scan_images_keeps_duplicate_content_as_distinct_entries(tmp_path):
+    pack_dir, memes_dir = create_pack(tmp_path)
+    for category in ("happy", "sad"):
+        category_dir = memes_dir / category
+        category_dir.mkdir()
+        (category_dir / "same.png").write_bytes(b"same")
+        (category_dir / "ignore.txt").write_bytes(b"same")
+    images = storage.scan_images(pack_dir)
+    assert len(images) == 2
+    assert images[0]["content_sha256"] == images[1]["content_sha256"]
+    assert images[0]["entry_id"] != images[1]["entry_id"]
+    assert {item["category"] for item in images} == {"happy", "sad"}
+
+
+def test_scan_images_returns_empty_without_memes_directory(tmp_path):
+    assert storage.scan_images(tmp_path / "missing") == []
+
+
+def test_save_and_load_empty_metadata_round_trip(tmp_path):
+    pack_dir, _ = create_pack(tmp_path)
+    target = storage.save_metadata(pack_dir, {"images": {}})
+    assert target.is_file()
+    loaded = storage.load_metadata(pack_dir)
+    assert loaded["schema_version"] == storage.SCHEMA_VERSION
+    assert loaded["pack_id"] == "pack"
+    assert loaded["images"] == {}
+
+
+def test_load_metadata_returns_new_payload_when_file_missing(tmp_path):
+    pack_dir, _ = create_pack(tmp_path)
+    loaded = storage.load_metadata(pack_dir)
+    assert loaded["pack_id"] == "pack"
+    assert loaded["images"] == {}
+
+
+def test_load_metadata_keeps_corrupt_or_future_file_read_only(tmp_path):
+    pack_dir, _ = create_pack(tmp_path)
+    metadata_file = pack_dir / "semantic_metadata.json"
+    metadata_file.write_text("not-json", encoding="utf-8")
+    corrupt = storage.load_metadata(pack_dir)
+    assert corrupt["metadata_read_only"]
+    assert "无法解析" in corrupt["metadata_error"]
+
+    metadata_file.write_text(
+        json.dumps({"schema_version": "99", "images": {}}), encoding="utf-8"
+    )
+    future = storage.load_metadata(pack_dir)
+    assert future["metadata_read_only"]
+    assert future["source_schema_version"] == "99"
+
+
+def test_save_metadata_refuses_read_only_and_corrupt_existing_files(tmp_path):
+    pack_dir, _ = create_pack(tmp_path)
+    with pytest.raises(storage.SemanticMetadataCompatibilityError):
+        storage.save_metadata(
+            pack_dir,
+            {"metadata_read_only": True, "metadata_error": "future version"},
+        )
+    (pack_dir / "semantic_metadata.json").write_text("not-json", encoding="utf-8")
+    with pytest.raises(storage.SemanticMetadataCompatibilityError):
+        storage.save_metadata(pack_dir, {"images": {}})
+
+
+def test_semantic_metadata_complete_requires_current_snapshot(tmp_path):
+    pack_dir, memes_dir = create_pack(tmp_path)
+    category_dir = memes_dir / "happy"
+    category_dir.mkdir()
+    image_path = category_dir / "meme.png"
+    image_path.write_bytes(b"image")
+    scanned = storage.scan_images(pack_dir)[0]
+    image = SemanticImage(
+        content_sha256=scanned["content_sha256"],
+        relative_path=scanned["relative_path"],
+        category="happy",
+        caption="猫在笑",
+        tags=["可爱"],
+        caption_status="done",
+        embedding_status="done",
+    )
+    image.category_review_status = "auto_match"
+    image.category_review_context_hash = image.category_context_hash
+    metadata = {
+        "file_total": 1,
+        "unique_total": 1,
+        "images": {scanned["entry_id"]: image.to_dict()},
+    }
+    storage.save_metadata(pack_dir, metadata)
+    loaded = storage.load_metadata(pack_dir)
+    assert storage.semantic_metadata_is_complete(pack_dir, loaded)
+    assert storage.semantic_metadata_is_complete(
+        pack_dir, loaded, require_embeddings=True
+    )
+    loaded["file_total"] = 2
+    assert not storage.semantic_metadata_is_complete(pack_dir, loaded)
+
+
+def test_semantic_summary_reports_none_and_complete(tmp_path):
+    pack_dir, memes_dir = create_pack(tmp_path)
+    assert storage.get_pack_semantic_summary(pack_dir)["semantic_status"] == "none"
+    category_dir = memes_dir / "happy"
+    category_dir.mkdir()
+    (category_dir / "meme.png").write_bytes(b"image")
+    scanned = storage.scan_images(pack_dir)[0]
+    image = SemanticImage(
+        content_sha256=scanned["content_sha256"],
+        relative_path=scanned["relative_path"],
+        category="happy",
+        caption="猫",
+        tags=["猫"],
+        caption_status="done",
+        embedding_status="done",
+    )
+    image.category_review_status = "auto_match"
+    image.category_review_context_hash = image.category_context_hash
+    storage.save_metadata(
+        pack_dir,
+        {
+            "file_total": 1,
+            "unique_total": 1,
+            "images": {scanned["entry_id"]: image.to_dict()},
+        },
+    )
+    summary = storage.get_pack_semantic_summary(pack_dir)
+    assert summary["semantic_status"] == "complete"
+    assert summary["semantic_caption_done"] == 1
+    assert summary["semantic_snapshot_matches"]
+
+
+def test_import_metadata_file_validates_shape(tmp_path):
+    path = tmp_path / "metadata.json"
+    with pytest.raises(FileNotFoundError):
+        storage.import_metadata_file(path)
+    path.write_text("[]", encoding="utf-8")
+    with pytest.raises(ValueError):
+        storage.import_metadata_file(path)
+    path.write_text(json.dumps({"images": {}}), encoding="utf-8")
+    assert storage.import_metadata_file(path) == {"images": {}}
+
+
+def test_metadata_items_filters_and_sorts(monkeypatch):
+    data = {
+        "images": {
+            "done": {
+                "relative_path": "z.png",
+                "caption_status": "done",
+                "embedding_status": "done",
+                "updated_at": "3",
+            },
+            "failed": {
+                "relative_path": "b.png",
+                "caption_status": "failed",
+                "embedding_status": "pending",
+                "updated_at": "2",
+            },
+            "running": {
+                "relative_path": "a.png",
+                "caption_status": "running",
+                "embedding_status": "pending",
+                "updated_at": "1",
+                "reclassification_status": "auto_reclassified",
+            },
+        }
+    }
+    monkeypatch.setattr(storage, "load_metadata", lambda pack_dir: data)
+    assert [item["relative_path"] for item in storage.metadata_items("pack")] == [
+        "a.png",
+        "b.png",
+        "z.png",
+    ]
+    assert len(storage.metadata_items("pack", "completed")) == 1
+    assert len(storage.metadata_items("pack", "failed")) == 1
+    assert len(storage.metadata_items("pack", "reclassified")) == 1
+    assert storage.metadata_items("pack", "unknown") == []
+
+
+def test_category_review_overview_is_unavailable_before_semantic_work(
+    tmp_path, monkeypatch
+):
+    pack_dir, _ = create_pack(tmp_path)
+    monkeypatch.setattr(
+        storage,
+        "get_pack_semantic_summary",
+        lambda pack_dir: {"semantic_status": "none"},
+    )
+    overview = storage.get_category_review_overview(pack_dir)
+    assert not overview["available"]
+    assert overview["statistics"]["total"] == 0

--- a/tests/test_semantic_task_helpers.py
+++ b/tests/test_semantic_task_helpers.py
@@ -1,0 +1,338 @@
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot_plugin_meme_manager.backend import semantic_task as task_module
+from astrbot_plugin_meme_manager.backend.semantic_task import (
+    SemanticTaskManager,
+    _revision_category_choice,
+    _revision_original_category,
+)
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return SemanticTaskManager(tmp_path, config={"concurrency": 4})
+
+
+def test_revision_original_category_prefers_direct_then_history():
+    item = SimpleNamespace(
+        category="review",
+        reclassified_from_category="happy",
+        reclassification_history=[{"from_category": "sad"}],
+    )
+    assert _revision_original_category(item, {"happy", "sad"}) == "happy"
+    item.reclassified_from_category = "missing"
+    assert _revision_original_category(item, {"happy", "sad"}) == "sad"
+    assert _revision_original_category(item, {"happy"}) == ""
+
+
+@pytest.mark.parametrize(
+    ("current", "original", "fit", "suggested", "expected"),
+    [
+        ("review", "happy", "conflict", "happy", ("happy", "return_original")),
+        ("review", "happy", "conflict", "sad", ("sad", "move_to_other")),
+        ("happy", "", "match", "", ("happy", "keep_current")),
+        ("happy", "", "uncertain", "", ("happy", "keep_current")),
+        ("review", "", "conflict", "missing", ("", "manual_required")),
+    ],
+)
+def test_revision_category_choice(current, original, fit, suggested, expected):
+    assert _revision_category_choice(
+        current_category=current,
+        original_category=original,
+        category_fit=fit,
+        suggested_category=suggested,
+        selectable_categories={"happy", "sad"},
+    ) == expected
+
+
+@pytest.mark.parametrize("value", ["", "a", "../pack", "中文", "a" * 65])
+def test_validate_pack_id_rejects_unsafe_values(value):
+    with pytest.raises(ValueError):
+        SemanticTaskManager._validate_pack_id(value)
+
+
+@pytest.mark.parametrize("value", ["ab", "pack-a", "pack_1.2"])
+def test_validate_pack_id_accepts_safe_values(value):
+    assert SemanticTaskManager._validate_pack_id(value) == value
+
+
+def test_state_selection_and_pack_paths_are_scoped(manager, tmp_path):
+    assert manager._state_path("pack-a") == (
+        tmp_path.resolve() / "semantic_indexes" / "pack-a" / "task_state.json"
+    )
+    assert manager._selection_path("pack-a").name == "provider_selection.json"
+    assert manager._pack_dir("pack-a") == tmp_path.resolve() / "packs" / "pack-a"
+
+
+def test_state_and_selection_round_trip_and_corrupt_fallback(manager):
+    manager._save_state("pack-a", {"task_status": "running"})
+    assert manager._load_state("pack-a") == {"task_status": "running"}
+    manager._save_json_atomic(
+        manager._selection_path("pack-a"), {"id": "embedding"}, ".selection."
+    )
+    assert manager._load_selection("pack-a") == {"id": "embedding"}
+    manager._state_path("pack-a").write_text("bad json", encoding="utf-8")
+    manager._selection_path("pack-a").write_text("[]", encoding="utf-8")
+    assert manager._load_state("pack-a") == {}
+    assert manager._load_selection("pack-a") == {}
+
+
+def test_external_operation_guards_mutations(manager, monkeypatch):
+    monkeypatch.setattr(manager, "_load_state", lambda pack_id: {})
+    manager.begin_external_pack_operation("pack-a", "同步")
+    with pytest.raises(RuntimeError):
+        manager.assert_pack_mutation_allowed("pack-a", "删除")
+    manager.end_external_pack_operation("pack-a")
+    manager.assert_pack_mutation_allowed("pack-a", "删除")
+
+
+@pytest.mark.parametrize("status", ["running", "paused"])
+def test_persisted_semantic_queue_guards_mutations(manager, monkeypatch, status):
+    monkeypatch.setattr(manager, "_load_state", lambda pack_id: {"task_status": status})
+    with pytest.raises(RuntimeError):
+        manager.assert_pack_mutation_allowed("pack-a", "重命名")
+
+
+def test_active_pack_tasks_reports_live_tasks(manager, monkeypatch):
+    class FakeTask:
+        def __init__(self, done):
+            self._done = done
+
+        def done(self):
+            return self._done
+
+    manager._tasks = {"pack-a": FakeTask(False), "pack-b": FakeTask(True)}
+    manager._index_tasks = {"pack-c": FakeTask(False)}
+    monkeypatch.setattr(
+        manager,
+        "_load_state",
+        lambda pack_id: {
+            "task_status": "running",
+            "task_phase": "indexing" if pack_id == "pack-c" else "captioning",
+            "concurrency": "3",
+        },
+    )
+    assert manager.active_pack_tasks(exclude_pack_id="pack-b") == [
+        {
+            "pack_id": "pack-a",
+            "task_status": "running",
+            "task_phase": "captioning",
+            "concurrency": 3,
+        },
+        {
+            "pack_id": "pack-c",
+            "task_status": "running",
+            "task_phase": "indexing",
+            "concurrency": 0,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [(0, 1), ("bad", 1), (5, 5), (99, 16)],
+)
+def test_configured_concurrency_is_bounded(tmp_path, configured, expected):
+    manager = SemanticTaskManager(tmp_path, config={"concurrency": configured})
+    assert manager._configured_concurrency() == expected
+
+
+def test_elapsed_seconds_handles_timezones_and_invalid_values():
+    assert SemanticTaskManager._elapsed_seconds(
+        "2026-01-01T00:00:00Z", "2026-01-01T00:00:03+00:00"
+    ) == 3
+    assert SemanticTaskManager._elapsed_seconds(
+        datetime(2026, 1, 1), datetime(2026, 1, 1, 0, 0, 2)
+    ) == 2
+    assert SemanticTaskManager._elapsed_seconds("bad", "bad") == 0
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, {"input": 0, "output": 0, "total": 0, "calls": 0}),
+        (
+            {"input": "2", "output": 3, "total": 0, "calls": -1},
+            {"input": 2, "output": 3, "total": 5, "calls": 0},
+        ),
+        (
+            {"input": "bad", "output": -3, "total": 8, "calls": 1},
+            {"input": 0, "output": 0, "total": 8, "calls": 1},
+        ),
+    ],
+)
+def test_token_usage_normalization(value, expected):
+    assert SemanticTaskManager._normalize_token_usage(value) == expected
+
+
+def test_record_vision_usage_accumulates_and_saves(manager, monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        manager,
+        "_load_state",
+        lambda pack_id: {"token_usage": {"input": 2, "total": 2, "calls": 1}},
+    )
+    monkeypatch.setattr(manager, "_save_state", lambda pack_id, state: saved.append(state))
+    manager._record_vision_usage("pack-a", {"output": 3})
+    assert saved[0]["token_usage"] == {
+        "input": 2,
+        "output": 3,
+        "total": 5,
+        "calls": 2,
+    }
+    assert saved[0]["vision_calls"] == 2
+
+
+def test_safe_error_redacts_local_paths_and_limits_length(manager):
+    error = f"failed at {manager._pack_dir('pack-a')} " + "x" * 600
+    result = manager._safe_error(error, "pack-a")
+    assert str(manager.plugin_data_dir) not in result
+    assert len(result) == 500
+
+
+def test_vision_provider_details_requires_image_capability(tmp_path):
+    provider = SimpleNamespace(
+        provider_config={"modalities": ["text"], "model": "vision-model"}
+    )
+    context = SimpleNamespace(
+        get_provider_by_id=lambda provider_id: provider,
+        llm_generate=lambda **kwargs: None,
+    )
+    manager = SemanticTaskManager(
+        tmp_path,
+        context=context,
+        config={"vision_provider_id": "vision"},
+    )
+    assert manager._vision_provider_details() == {
+        "id": "vision",
+        "model": "",
+        "ready": False,
+    }
+    provider.provider_config["modalities"] = ["text", "image"]
+    assert manager._vision_provider_details() == {
+        "id": "vision",
+        "model": "vision-model",
+        "ready": True,
+    }
+
+
+def test_persist_provider_selection_preserves_matching_verification(manager):
+    manager._save_json_atomic(
+        manager._selection_path("pack-a"),
+        {
+            "effective_provider_id": "provider",
+            "embedding_model": "model",
+            "configured_dimension": 8,
+            "dimension_verified": True,
+            "verified_dimension": 8,
+            "verified_at": "earlier",
+        },
+        ".selection.",
+    )
+    embedding = SimpleNamespace(
+        ready=True,
+        provider_id="provider",
+        model_name="model",
+        dimension=8,
+    )
+    result = manager._persist_provider_selection("pack-a", embedding, "configured")
+    assert result["dimension_verified"] is True
+    assert result["verified_dimension"] == 8
+    assert result["selection_mode"] == "configured"
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_all_live_tasks(manager):
+    started = asyncio.Event()
+
+    async def wait_forever():
+        started.set()
+        await asyncio.Event().wait()
+
+    first = asyncio.create_task(wait_forever())
+    second = asyncio.create_task(wait_forever())
+    manager._tasks["pack-a"] = first
+    manager._index_tasks["pack-b"] = second
+    await started.wait()
+    await manager.close()
+    assert first.cancelled()
+    assert second.cancelled()
+
+
+@pytest.mark.parametrize(
+    ("state", "metadata", "external", "expected"),
+    [
+        ({}, {"images": {}}, "", "empty"),
+        ({"queue_cleared": True}, {"images": {}}, "", "cleared"),
+        ({}, {"images": {}}, "同步", "external_operation"),
+        (
+            {},
+            {"images": {}, "metadata_read_only": True, "metadata_error": "broken"},
+            "",
+            "metadata_error",
+        ),
+    ],
+)
+def test_status_reports_primary_queue_states(
+    manager, monkeypatch, state, metadata, external, expected
+):
+    adapter = SimpleNamespace(
+        ready=False,
+        provider_id="",
+        model_name="",
+        dimension=0,
+        provider=None,
+    )
+    monkeypatch.setattr(task_module, "load_metadata", lambda pack_dir: metadata)
+    monkeypatch.setattr(task_module, "load_index_manifest", lambda *args: {})
+    monkeypatch.setattr(manager, "_load_state", lambda pack_id: state)
+    monkeypatch.setattr(manager, "_embedding_adapter", lambda pack_id: adapter)
+    monkeypatch.setattr(manager, "_load_selection", lambda pack_id: {})
+    monkeypatch.setattr(manager, "_vision_provider_details", lambda: {"id": "", "model": "", "ready": False})
+    monkeypatch.setattr(manager, "capabilities", lambda *args, **kwargs: {})
+    if external:
+        manager._external_pack_operations["pack-a"] = external
+
+    assert manager.status("pack-a")["queue_status"] == expected
+
+
+@pytest.mark.parametrize(
+    ("item", "expected"),
+    [
+        (None, False),
+        ({"caption_status": "pending"}, True),
+        ({"embedding_status": "failed", "current": True}, True),
+        (
+            {"caption_status": "done", "embedding_status": "done", "current": True},
+            False,
+        ),
+    ],
+)
+def test_item_queue_detection(monkeypatch, item, expected):
+    monkeypatch.setattr(
+        task_module,
+        "category_analysis_is_current",
+        lambda value: bool(value.get("current")),
+    )
+    assert SemanticTaskManager._item_is_queued(item) is expected
+
+
+def test_reset_running_items_returns_them_to_pending(manager, monkeypatch):
+    metadata = {
+        "images": {
+            "a": {"caption_status": "running", "embedding_status": "done"},
+            "b": {"caption_status": "done", "embedding_status": "running"},
+            "c": {"caption_status": "done", "embedding_status": "done"},
+        }
+    }
+    saved = []
+    monkeypatch.setattr(task_module, "save_metadata", lambda path, data: saved.append(data))
+    result, recovered = manager._reset_running_items("pack-a", metadata)
+    assert result["images"]["a"]["caption_status"] == "pending"
+    assert result["images"]["b"]["embedding_status"] == "pending"
+    assert recovered == 2
+    assert saved == [metadata]

--- a/tests/test_sync_manager.py
+++ b/tests/test_sync_manager.py
@@ -3,7 +3,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+from image_host.core.file_handler import FileHandler
 from image_host.core.sync_manager import SyncManager
+from image_host.core.upload_tracker import UploadTracker
 from image_host.providers import stardots_provider
 
 
@@ -62,9 +65,7 @@ class SyncFailureReportingTests(unittest.TestCase):
             image_host = FakeImageHost()
             manager = SyncManager(image_host, Path(temp_dir))
             manager.check_sync_status = lambda: {
-                "to_delete_remote": [
-                    {"id": "remote.png", "filename": "remote.png"}
-                ]
+                "to_delete_remote": [{"id": "remote.png", "filename": "remote.png"}]
             }
             manager.sync_to_remote = lambda: False
 
@@ -115,7 +116,10 @@ class StarDotsFilenameRegressionTests(unittest.TestCase):
             ("animals/cats", "animals@@DIR@@cats@@CAT@@meme.png"),
         )
         for category, expected_remote_name in cases:
-            with self.subTest(category=category), tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                self.subTest(category=category),
+                tempfile.TemporaryDirectory() as temp_dir,
+            ):
                 provider = object.__new__(stardots_provider.StarDotsProvider)
                 provider.space = "test-space"
                 provider.base_url = "https://api.stardots.io"
@@ -142,6 +146,196 @@ class StarDotsFilenameRegressionTests(unittest.TestCase):
                 self.assertTrue(downloaded)
                 self.assertEqual(requested_filenames, [expected_remote_name])
                 self.assertEqual(save_path.stat().st_size, 1001)
+
+
+class SyncStatusTests(unittest.TestCase):
+    def test_file_handler_scans_supported_images_with_relative_categories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "animals" / "cats").mkdir(parents=True)
+            (root / "animals" / "cats" / "meme.PNG").write_bytes(b"image")
+            (root / "ignore.txt").write_bytes(b"ignore")
+            images = FileHandler(root).scan_local_images()
+            self.assertEqual(
+                images,
+                [
+                    {
+                        "path": str(root / "animals" / "cats" / "meme.PNG"),
+                        "id": "animals/cats/meme.PNG",
+                        "filename": "meme.PNG",
+                        "category": "animals/cats",
+                    }
+                ],
+            )
+
+    def test_remote_id_normalization_supports_all_providers(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manager = SyncManager(FakeImageHost(), Path(temp_dir))
+            self.assertEqual(
+                manager._normalize_remote_id("/memes/happy/meme.png", "cloudflare_r2"),
+                "happy/meme.png",
+            )
+            manager.image_host.config = {"base_path": "remote/memes"}
+            self.assertEqual(
+                manager._normalize_remote_id("remote/memes/happy/meme.png", "webdav"),
+                "happy/meme.png",
+            )
+            self.assertEqual(
+                manager._normalize_remote_id(
+                    "animals@@DIR@@cats@@CAT@@meme.png", "stardots"
+                ),
+                "animals/cats/meme.png",
+            )
+            self.assertEqual(
+                manager._normalize_remote_id("@@CAT@@meme.png", "unknown"),
+                "meme.png",
+            )
+
+    def test_sync_status_classifies_local_and_remote_differences(self):
+        class ListedImageHost(FakeImageHost):
+            config = {"provider": "cloudflare_r2"}
+
+            @staticmethod
+            def get_image_list():
+                return [
+                    {
+                        "id": "memes/common.png",
+                        "filename": "common.png",
+                        "category": "",
+                        "size": "6",
+                    },
+                    {
+                        "id": "memes/remote.png",
+                        "filename": "remote.png",
+                        "category": "",
+                        "fileSize": 10,
+                    },
+                ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "common.png").write_bytes(b"common")
+            (root / "local.png").write_bytes(b"only")
+            manager = SyncManager(ListedImageHost(), root)
+            status = manager.check_sync_status()
+            self.assertEqual(
+                [item["filename"] for item in status["to_upload"]], ["local.png"]
+            )
+            self.assertEqual(
+                [item["filename"] for item in status["to_download"]], ["remote.png"]
+            )
+            self.assertEqual(status["to_delete_remote"], status["to_download"])
+            self.assertEqual(
+                [item["filename"] for item in status["to_delete_local"]],
+                ["local.png"],
+            )
+            self.assertFalse(status["is_synced"])
+            self.assertEqual(status["remote_image_count"], 2)
+            self.assertEqual(status["remote_total_bytes"], 16)
+            self.assertEqual(status["local_total_bytes"], 10)
+
+    def test_sync_status_uses_tracker_and_estimates_missing_remote_sizes(self):
+        class ListedImageHost(FakeImageHost):
+            config = {"provider": "webdav"}
+
+            @staticmethod
+            def get_image_list():
+                return [
+                    {
+                        "id": "common.png",
+                        "filename": "common.png",
+                        "category": "",
+                    }
+                ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            image_path = root / "common.png"
+            image_path.write_bytes(b"common")
+            tracker = UploadTracker(root / ".tracker.json")
+            manager = SyncManager(ListedImageHost(), root, tracker)
+            status = manager.check_sync_status()
+            self.assertEqual(status["to_upload"][0]["filename"], "common.png")
+            self.assertEqual(status["remote_size_source"], "local_estimate")
+            self.assertEqual(status["remote_total_bytes_estimated"], 6)
+
+    def test_sync_success_uploads_downloads_and_updates_tracker(self):
+        class SuccessfulImageHost(FakeImageHost):
+            def __init__(self):
+                super().__init__()
+                self.uploaded = []
+
+            def upload_image(self, file_path):
+                self.uploaded.append(file_path.name)
+                return {"url": f"https://example/{file_path.name}"}
+
+            def download_image(self, image_info, save_path):
+                save_path.write_bytes(b"downloaded")
+                return True
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            upload_path = root / "upload.png"
+            upload_path.write_bytes(b"upload")
+            tracker = UploadTracker(root / ".tracker.json")
+            image_host = SuccessfulImageHost()
+            manager = SyncManager(image_host, root, tracker)
+            manager.check_sync_status = lambda: {
+                "is_synced": False,
+                "to_upload": [
+                    {
+                        "path": str(upload_path),
+                        "filename": upload_path.name,
+                        "category": "",
+                    }
+                ],
+            }
+            self.assertTrue(manager.sync_to_remote())
+            self.assertEqual(image_host.uploaded, ["upload.png"])
+            self.assertTrue(tracker.is_uploaded(upload_path))
+
+            manager.check_sync_status = lambda: {
+                "is_synced": False,
+                "to_download": [
+                    {
+                        "id": "happy/download.png",
+                        "filename": "download.png",
+                        "category": "happy",
+                    }
+                ],
+            }
+            self.assertTrue(manager.sync_from_remote())
+            self.assertEqual(
+                (root / "happy" / "download.png").read_bytes(), b"downloaded"
+            )
+
+    def test_overwrite_reports_delete_failures(self):
+        class FailedDeleteHost(FakeImageHost):
+            def delete_image(self, image_id):
+                return False
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manager = SyncManager(FailedDeleteHost(), Path(temp_dir))
+            manager.check_sync_status = lambda: {
+                "to_delete_remote": [{"id": "remote.png", "filename": "remote.png"}]
+            }
+            manager.sync_to_remote = lambda: True
+            self.assertFalse(manager.overwrite_to_remote())
+
+
+@pytest.mark.parametrize(
+    ("image_info", "expected"),
+    [
+        ({"size": 12}, 12),
+        ({"file_size": 3.8}, 3),
+        ({"bytes": "9"}, 9),
+        ({"length": "bad"}, None),
+        ({}, None),
+    ],
+)
+def test_extract_remote_size(image_info, expected):
+    manager = object.__new__(SyncManager)
+    assert manager._extract_remote_size(image_info) == expected
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_and_tracker.py
+++ b/tests/test_utils_and_tracker.py
@@ -1,0 +1,147 @@
+import json
+import re
+from pathlib import Path
+
+import pytest
+import utils
+from image_host.core.upload_tracker import UploadTracker
+
+
+def test_json_helpers_round_trip_unicode_and_default(tmp_path):
+    target = tmp_path / "nested" / "data.json"
+    assert utils.save_json({"message": "开心"}, str(target))
+    assert utils.load_json(str(target)) == {"message": "开心"}
+    assert utils.load_json(str(tmp_path / "missing.json"), {"fallback": True}) == {
+        "fallback": True
+    }
+
+
+def test_save_json_reports_write_failure(tmp_path, monkeypatch):
+    def fail_open(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("builtins.open", fail_open)
+    assert not utils.save_json({"value": 1}, str(tmp_path / "data.json"))
+
+
+def test_dictionary_probability_and_secret_helpers(monkeypatch):
+    assert utils.dict_to_string({"a": 1, "b": 2}) == "a - 1\n\nb - 2\n"
+    assert utils.normalize_probability("20") == 20
+    assert utils.normalize_probability(-1) == 0
+    assert utils.normalize_probability(101) == 100
+    assert utils.normalize_probability("bad") == 0
+    assert not utils.probability_hit(0, roll=1)
+    assert utils.probability_hit(100, roll=100)
+    assert utils.probability_hit(50, roll=50)
+    assert not utils.probability_hit(50, roll=51)
+    monkeypatch.setattr(utils.random, "randint", lambda start, end: 25)
+    assert utils.probability_hit(30)
+    secret = utils.generate_secret_key(24)
+    assert len(secret) == 24
+    assert re.fullmatch(r"[A-Za-z0-9]{24}", secret)
+
+
+@pytest.mark.asyncio
+async def test_get_public_ip_skips_failures_and_invalid_values(monkeypatch):
+    class Response:
+        def __init__(self, status, text):
+            self.status = status
+            self.value = text
+
+        async def __aenter__(self):
+            if isinstance(self.value, Exception):
+                raise self.value
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def text(self):
+            return self.value
+
+    class Session:
+        def __init__(self):
+            self.responses = iter(
+                [
+                    Response(500, "error"),
+                    Response(200, "not-an-ip"),
+                    Response(200, " 1.2.3.4 \n"),
+                ]
+            )
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        def get(self, url, timeout):
+            return next(self.responses)
+
+    monkeypatch.setattr(utils.aiohttp, "ClientSession", Session)
+    assert await utils.get_public_ip() == "1.2.3.4"
+
+
+@pytest.mark.asyncio
+async def test_get_public_ip_returns_placeholder_when_all_requests_fail(monkeypatch):
+    class Response:
+        async def __aenter__(self):
+            raise OSError("offline")
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    class Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        def get(self, url, timeout):
+            return Response()
+
+    monkeypatch.setattr(utils.aiohttp, "ClientSession", Session)
+    assert await utils.get_public_ip() == "[服务器公网ip]"
+
+
+def test_upload_tracker_persists_marks_removals_and_clear(tmp_path):
+    tracker_path = tmp_path / "state" / "tracker.json"
+    image_path = tmp_path / "meme.png"
+    image_path.write_bytes(b"image")
+    tracker = UploadTracker(tracker_path)
+    assert tracker.get_uploaded_count() == 0
+    assert not tracker.is_uploaded(image_path, "happy")
+
+    tracker.mark_uploaded(image_path, "happy", "https://example/meme.png")
+    assert tracker.is_uploaded(image_path, "happy")
+    assert tracker.get_uploaded_count() == 1
+    saved = json.loads(tracker_path.read_text(encoding="utf-8"))
+    assert saved[str(Path("happy") / "meme.png")]["file_size"] == 5
+
+    reloaded = UploadTracker(tracker_path)
+    assert reloaded.is_uploaded(image_path, "happy")
+    reloaded.remove_record(image_path, "happy")
+    assert not reloaded.is_uploaded(image_path, "happy")
+    reloaded.mark_uploaded(tmp_path / "missing.png")
+    assert reloaded.uploaded_files["missing.png"]["file_size"] == 0
+    reloaded.clear_record()
+    assert reloaded.get_uploaded_count() == 0
+
+
+def test_upload_tracker_recovers_from_corrupt_file(tmp_path):
+    tracker_path = tmp_path / "tracker.json"
+    tracker_path.write_text("not-json", encoding="utf-8")
+    tracker = UploadTracker(tracker_path)
+    assert tracker.uploaded_files == {}
+
+
+def test_upload_tracker_swallows_save_errors(tmp_path, monkeypatch):
+    tracker = UploadTracker(tmp_path / "tracker.json")
+
+    def fail_open(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("builtins.open", fail_open)
+    tracker.uploaded_files = {"meme.png": {}}
+    tracker.save()


### PR DESCRIPTION
## What changed

- Added unit tests across configuration, category management, pack protocol and storage, semantic models, storage, indexing, captioning, task state, synchronization, and provider helpers.
- Added boundary tests for command, event handler, Web API, initialization, and main plugin helpers.
- Expanded synchronization manager regression coverage, including partial failures and overwrite behavior.

## Why

The plugin had broad untested areas around semantic processing, storage synchronization, provider path normalization, and orchestration helpers. These tests protect the recent security and consistency fixes and make future regressions easier to detect.

## Impact

No production behavior changes. The suite now exercises every production module, with 431 passing tests plus 75 passing subtests and 42% production-code coverage.

## Validation

- `uv run pytest -q`
- `uv run coverage run --source=. -m pytest -q`
- `uv run coverage report --omit="tests/*"`
- `uv run ruff format .`
- `uv run ruff check .`
- `git diff --check`
