### PR TITLE
fix(storage): 图床初始化——R2 探测失败降级、异常兜底与启动不阻塞

### DIFF
--- a/main.py
+++ b/main.py
@@ -477,11 +477,22 @@ class MemeSender(Star, WebAPIMixin, CommandMixin, EventHandlerMixin):
                 current_dir = None
 
         if current_dir != target_memes_dir.resolve():
-            self.img_sync = ImageSync(
-                config=self.img_sync_config,
-                local_dir=target_memes_dir,
-                provider_type=self.img_sync_provider_type,
-            )
+            # 图床客户端构造可能因网络不可达/凭据错误抛错（如 R2 head_bucket 探测），
+            # 此处兜底为“图床不可用”降级，避免阻塞插件加载与指令/WebUI 使用。
+            try:
+                self.img_sync = ImageSync(
+                    config=self.img_sync_config,
+                    local_dir=target_memes_dir,
+                    provider_type=self.img_sync_provider_type,
+                )
+            except Exception as exc:
+                logger.error(
+                    "图床 %s 初始化失败，图床功能暂不可用: %s",
+                    self.img_sync_provider_type,
+                    exc,
+                )
+                self.img_sync = None
+                return None
 
         self._img_sync_pack_id = target_pack_id
         return self.img_sync


### PR DESCRIPTION
  ## 问题与修复

   ### 1. R2 配置错误或网络不可达时插件整体加载失败 Fixes #117 

   **问题描述**：配置选择 `cloudflare_r2` 且四个必填字段
 （`account_id`/`access_key_id`/`secret_access_key`/`bucket_name`）齐全时，只要 R2 凭据错误、bucket 不存在或网络不可达
 ，插件加载直接失败，本地表情、WebUI、全部指令均不可用。

   **根因**：`CloudflareR2Provider.__init__` 在构造期同步执行 `s3_client.head_bucket()` 连通性探测，`ClientError` 原样
 `raise`；而插件 `__init__` 中 `_ensure_img_sync_for_pack()` 调用（`main.py`）对 `ImageSync(...)` 构造无任何异常兜底，
 异常穿透 `__init__` 导致 AstrBot 判定插件加载失败。四个图床 provider 中仅 R2 在构造期做无保护网络探测（Stardots 的
 `_sync_server_time()` 有 try/except 兜底，WebDAV 构造纯本地无网络调用），行为不对称。

   **修复：**
   - `MemeSender._ensure_img_sync_for_pack()` 内 `ImageSync(...)` 构造包 try/except：失败时 `logger.error` 记录
 provider 类型与原始异常，置 `self.img_sync = None` 并返回 `None`
   - 下游所有 `if not sync_client:` 降级分支（指令层 5 处：`同步状态`/`同步到云端`/`从云端同步`/`覆盖到云端`/`从云端覆
 盖`；Web API 6 处：`_start_img_host_sync_task`、`_api_img_host_sync_status` 及上传/下载/覆盖路由）自然生效，统一提示"
 图床服务尚未配置"
   - 一处改动同时覆盖启动期（`__init__` 首次构建）与运行期（切换表情包时按目录重建）两条路径

