### PR TITLE
chore: normalize plugin metadata and logo

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: meme_manager
 display_name: 表情包管理器
 desc: anka - 表情包管理器 v4.15！提供 AstrBot WebUI 管理页面、资源广场与语义表情包页，支持官方/社区包安装、多表情包管理、情感模型辅助、不同会话/人格选包、云端同步与自动维护 prompt。欢迎大家创作自己的社区表情包集合！
 help: 功能：1. AI自动发送表情包 2. WebUI插件页面管理与资源广场 3. /表情管理 恢复默认表情包 4. /表情管理 查看图库 5. /表情管理 添加表情 [类别] 6. /表情管理 同步到云端 7. /表情管理 从云端同步 8. /表情管理 同步状态
-version: v4.15
+version: 4.15.0
 author: anka
 repo: https://github.com/anka-afk/astrbot_plugin_meme_manager


### PR DESCRIPTION
## What changed

- Updated the plugin version from `v4.15` to valid semver `4.15.0`.
- Added a concise marketplace description, a structured multiline description, the minimum AstrBot version, author profile, and search tags.
- Losslessly optimized `logo.png` while preserving its 2048×2048 RGBA pixels exactly.

## Why

The previous version did not satisfy strict semantic-version validation, and the plugin metadata did not expose the newer optional marketplace fields. The logo also contained avoidable PNG encoding overhead.

## Impact

- Version-aware tooling can accept the plugin metadata.
- Marketplace cards and search receive richer plugin information.
- The logo is 889,256 bytes smaller (18.2%) with no visual or pixel changes.

## Validation

- YAML parsing and metadata type assertions
- Exact `MAJOR.MINOR.PATCH` version validation
- PEP 440 AstrBot version specifier validation
- PNG format, dimensions, mode, and decoded pixel SHA-256 comparison
- `uv run ruff format --check .`
- `uv run ruff check .`