### PR TITLE
chore: release version 4.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 本文件记录 AstrBot 表情包管理器的版本更新，最新版本排在最前。
 
+## v4.15.5
+
+- 🧠 修复 SiliconFlow 等视觉模型在语义化及人工复审时返回 `tool_choice` 的 `not yet supported` 错误后，未能触发自动降级的问题（[#123](https://github.com/anka-afk/astrbot_plugin_meme_manager/issues/123)）。
+- 🔄 补齐工具调用和结构化输出的兼容性错误识别：工具参数被拒绝后自动改用无工具的 JSON 请求，`response_format` 也不受支持时继续退回普通 JSON 提示词。
+- 💰 复用已有 Provider 降级缓存，避免同一上下文中的后续图片重复尝试不受支持的工具调用。
+- 🛡️ 网络超时、认证失败等无关错误继续上抛，不误触发降级。
+- ✅ 新增原始报错、降级重试、模式缓存及无关错误不误判的回归测试；完整插件测试通过（451 项测试、81 项子测试）。
+
 ## v4.15.4
 
 - 🧠 修复 Gemini 视觉模型执行语义化及人工复审时，因 `suggested_category` 工具参数包含空字符串枚举而返回 `INVALID_ARGUMENT` 的问题。

--- a/README.md
+++ b/README.md
@@ -447,11 +447,11 @@ async def send_in_two_steps(context, event, chain: MessageChain):
 
 ## 📜 更新日志
 
-当前版本：v4.15.4
+当前版本：v4.15.5
 
-- 🧠 修复 Gemini 视觉模型执行语义化及人工复审时，工具 schema 因空字符串枚举被拒绝的问题。
-- 🛡️ 分类建议仍在模型响应后经过现有分类白名单校验，未知分类不会被采用。
-- ✅ 新增工具 schema 回归测试并完成完整插件测试。
+- 🧠 修复 SiliconFlow 等视觉模型返回 `tool_choice is not yet supported` 时，语义化及人工复审直接失败的问题。
+- 🔄 正确识别该兼容性错误并自动改用无工具的 JSON 请求；同一 Provider 后续图片复用降级模式，结构化输出也不受支持时继续退回普通 JSON 提示词。
+- ✅ 新增原始报错、降级重试、模式缓存及无关错误不误判的回归测试。
 
 完整版本记录请查看 [CHANGELOG.md](./CHANGELOG.md)。
 

--- a/backend/semantic_caption.py
+++ b/backend/semantic_caption.py
@@ -421,6 +421,7 @@ def _structured_output_is_unsupported(exc: Exception) -> bool:
         for marker in (
             "unsupported",
             "not support",
+            "not yet support",
             "does not support",
             "unknown",
             "unrecognized",
@@ -461,6 +462,7 @@ def _tool_call_is_unsupported(exc: Exception) -> bool:
         for marker in (
             "unsupported",
             "not support",
+            "not yet support",
             "does not support",
             "doesn't support",
             "not enabled",

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,7 +6,7 @@ desc: >-
   支持官方及社区资源包安装、多表情包管理、AI 智能发送、自动收集、
   会话与人格选包、云端同步，以及 prompt 自动维护。
 help: 功能：1. AI自动发送表情包 2. WebUI插件页面管理与资源广场 3. /表情管理 恢复默认表情包 4. /表情管理 查看图库 5. /表情管理 添加表情 [类别] 6. /表情管理 同步到云端 7. /表情管理 从云端同步 8. /表情管理 同步状态
-version: 4.15.4
+version: 4.15.5
 author: anka
 repo: https://github.com/anka-afk/astrbot_plugin_meme_manager
 astrbot_version: ">=4.17.0"

--- a/tests/test_semantic_caption.py
+++ b/tests/test_semantic_caption.py
@@ -1,9 +1,17 @@
+import asyncio
+import json
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from backend import semantic_caption as caption
 from PIL import Image
+
+SILICONFLOW_TOOL_CHOICE_ERROR = (
+    "Error code: 400 - {'code': 20015, 'message': 'Value error, The `required` "
+    "option for tool_choice is not yet supported.', 'data': None}"
+)
 
 
 def test_build_caption_tool_set_allows_empty_suggested_category():
@@ -132,6 +140,7 @@ def test_merge_token_usage_ignores_invalid_and_negative_values():
     ("message", "expected"),
     [
         ("response_format is unsupported", True),
+        ("response_format is not yet supported", True),
         ("结构化输出不支持", True),
         ("network unavailable", False),
     ],
@@ -144,6 +153,7 @@ def test_structured_output_unsupported_detection(message, expected):
     ("message", "expected"),
     [
         ("tool_choice is unsupported", True),
+        (SILICONFLOW_TOOL_CHOICE_ERROR, True),
         ("工具调用未启用", True),
         ("request timed out", False),
         ("tools request timed out", False),
@@ -151,6 +161,64 @@ def test_structured_output_unsupported_detection(message, expected):
 )
 def test_tool_call_unsupported_detection(message, expected):
     assert caption._tool_call_is_unsupported(RuntimeError(message)) is expected
+
+
+@pytest.mark.parametrize("json_format_supported", [True, False])
+def test_generate_caption_falls_back_and_caches_siliconflow_mode(
+    tmp_path, json_format_supported
+):
+    image_path = tmp_path / "meme.png"
+    Image.new("RGB", (2, 2), "red").save(image_path)
+    response = {
+        "completion_text": json.dumps(
+            {"caption": "A happy cat", "tags": ["happy"], "category_fit": "match"}
+        )
+    }
+    effects = [RuntimeError(SILICONFLOW_TOOL_CHOICE_ERROR)]
+    for _ in range(2):
+        if not json_format_supported:
+            effects.append(RuntimeError("response_format is not yet supported"))
+        effects.append(response)
+    context = SimpleNamespace(llm_generate=AsyncMock(side_effect=effects))
+
+    for _ in range(2):
+        result = asyncio.run(
+            caption.generate_caption(context, image_path, provider_id="siliconflow")
+        )
+        assert result["caption"] == "A happy cat"
+        assert result["tags"] == ["happy"]
+
+    requests = [call.kwargs for call in context.llm_generate.await_args_list]
+    assert len(requests) == (3 if json_format_supported else 5)
+    assert requests[0]["tool_choice"] == "required"
+    assert not requests[0]["tools"].empty()
+    for request in requests[1:]:
+        assert "tools" not in request
+        assert "tool_choice" not in request
+        assert caption.CAPTION_TOOL_PROMPT_SUFFIX not in request["prompt"]
+        assert request["image_urls"] == [str(image_path.resolve())]
+    assert caption._caption_output_mode(context, "siliconflow") == "json"
+    assert caption._caption_output_mode(context, "other-provider") == ""
+    if not json_format_supported:
+        assert "response_format" not in requests[2]
+        assert "response_format" not in requests[4]
+
+
+@pytest.mark.parametrize(
+    "message", ["tools request timed out", "Error code: 401 - Invalid API key"]
+)
+def test_generate_caption_does_not_downgrade_unrelated_errors(tmp_path, message):
+    error = RuntimeError(message)
+    context = SimpleNamespace(llm_generate=AsyncMock(side_effect=error))
+    with pytest.raises(RuntimeError) as caught:
+        asyncio.run(
+            caption.generate_caption(
+                context, tmp_path / "meme.png", provider_id="siliconflow"
+            )
+        )
+    assert caught.value is error
+    assert context.llm_generate.await_count == 1
+    assert caption._caption_output_mode(context, "siliconflow") == ""
 
 
 def test_caption_output_mode_cache():


### PR DESCRIPTION
SiliconFlow caption requests failed outright when tool_choice=required returned "not yet supported", because the existing compatibility detection did not recognize that wording. Recognize it for both tool calls and response_format so caption generation can use the existing JSON fallback and per-provider cache.

Update metadata.yaml, the README update section, and CHANGELOG.md to v4.15.5. Related issue: #123.

Validation: 451 plugin tests and 81 subtests passed; ruff format . and ruff check . passed. Regression tests cover the reported error, JSON and prompt-only fallback, provider cache reuse, and propagation of unrelated timeout/authentication errors. No live SiliconFlow API call was performed.